### PR TITLE
Add HTTPS option

### DIFF
--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -22,7 +22,7 @@ LOADING_NODES_NAME = 'elasticsearch-es-data-loading*'
 
 class ElasticsearchClient:
 
-    def __init__(self, host='localhost', port='9200', es_username='pipeline', es_password=None):
+    def __init__(self, host='localhost', port='9200', es_username='pipeline', es_password=None, es_scheme='http'):
         """Constructor.
 
         Args:
@@ -30,16 +30,18 @@ class ElasticsearchClient:
             port (str): Elasticsearch server port
             es_username (str): Elasticsearch username
             es_password (str): Elasticsearch password
+            es_scheme (str): Whether to use http or https
         """
 
         self._host = host
         self._port = port
         self._es_username = es_username
         self._es_password = es_password
+        self._es_scheme = es_scheme
 
         http_auth =  (self._es_username, self._es_password) if self._es_password else None
 
-        self.es = elasticsearch.Elasticsearch(host, port=port, http_auth=http_auth, scheme='https')
+        self.es = elasticsearch.Elasticsearch(host, port=port, http_auth=http_auth, scheme=es_scheme)
 
         # check connection
         logger.info(pformat(self.es.info()))

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -39,7 +39,7 @@ class ElasticsearchClient:
 
         http_auth =  (self._es_username, self._es_password) if self._es_password else None
 
-        self.es = elasticsearch.Elasticsearch(host, port=port, http_auth=http_auth)
+        self.es = elasticsearch.Elasticsearch(host, port=port, http_auth=http_auth, scheme='https')
 
         # check connection
         logger.info(pformat(self.es.info()))

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -22,7 +22,7 @@ LOADING_NODES_NAME = 'elasticsearch-es-data-loading*'
 
 class ElasticsearchClient:
 
-    def __init__(self, host='localhost', port='9200', es_username='pipeline', es_password=None, es_scheme='http'):
+    def __init__(self, host='localhost', port='9200', es_username='pipeline', es_password=None, es_use_ssl=False):
         """Constructor.
 
         Args:
@@ -30,18 +30,18 @@ class ElasticsearchClient:
             port (str): Elasticsearch server port
             es_username (str): Elasticsearch username
             es_password (str): Elasticsearch password
-            es_scheme (str): Whether to use http or https
+            es_use_ssl (bool): Whether to use SSL for ElasticSearch connections
         """
 
         self._host = host
         self._port = port
         self._es_username = es_username
         self._es_password = es_password
-        self._es_scheme = es_scheme
+        self._es_use_ssl = es_use_ssl
 
         http_auth =  (self._es_username, self._es_password) if self._es_password else None
 
-        self.es = elasticsearch.Elasticsearch(host, port=port, http_auth=http_auth, scheme=es_scheme)
+        self.es = elasticsearch.Elasticsearch(host, port=port, http_auth=http_auth, use_ssl=es_use_ssl)
 
         # check connection
         logger.info(pformat(self.es.info()))

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -125,6 +125,9 @@ class ElasticsearchClient(BaseElasticsearchClient):
                 'es.net.http.auth.pass': self._es_password,
             })
 
+        elasticsearch_config["es.nodes.wan.only"] = "true"
+        elasticsearch_config["es.net.ssl"] = "true"
+
         # encode any special chars in column names
         rename_dict = {}
         for field_name in table.row_value.dtype.fields:

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -125,8 +125,10 @@ class ElasticsearchClient(BaseElasticsearchClient):
                 'es.net.http.auth.pass': self._es_password,
             })
 
-        elasticsearch_config["es.nodes.wan.only"] = "true"
-        elasticsearch_config["es.net.ssl"] = "true"
+        # If using HTTPS, the instance is likely managed, in which case we can't
+        # discover nodes.
+        if self._es_scheme == 'https':
+            elasticsearch_config["es.nodes.wan.only"] = "true"
 
         # encode any special chars in column names
         rename_dict = {}

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -125,9 +125,9 @@ class ElasticsearchClient(BaseElasticsearchClient):
                 'es.net.http.auth.pass': self._es_password,
             })
 
-        if self._es_scheme == 'https':
+        if self._es_use_ssl:
             elasticsearch_config['es.net.ssl'] = 'true'
-            # If using HTTPS, the instance is likely managed, in which case we
+            # If using SSL, the instance is likely managed, in which case we
             # can't discover nodes.
             elasticsearch_config['es.nodes.wan.only'] = 'true'
 

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -125,9 +125,10 @@ class ElasticsearchClient(BaseElasticsearchClient):
                 'es.net.http.auth.pass': self._es_password,
             })
 
-        # If using HTTPS, the instance is likely managed, in which case we can't
-        # discover nodes.
         if self._es_scheme == 'https':
+            elasticsearch_config['es.net.ssl'] = 'true'
+            # If using HTTPS, the instance is likely managed, in which case we
+            # can't discover nodes.
             elasticsearch_config['es.nodes.wan.only'] = 'true'
 
         # encode any special chars in column names

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -128,7 +128,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         # If using HTTPS, the instance is likely managed, in which case we can't
         # discover nodes.
         if self._es_scheme == 'https':
-            elasticsearch_config["es.nodes.wan.only"] = "true"
+            elasticsearch_config['es.nodes.wan.only'] = 'true'
 
         # encode any special chars in column names
         rename_dict = {}

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -200,6 +200,7 @@ class HailElasticSearchTask(luigi.Task):
     use_temp_loading_nodes = luigi.BoolParameter(default=True, description='Whether to use temporary loading nodes.')
     es_host = luigi.Parameter(description='ElasticSearch host.', default='localhost')
     es_port = luigi.IntParameter(description='ElasticSearch port.', default=9200)
+    es_scheme = luigi.Parameter(description='ElastisSearch scheme (http or https)', default='http')
     es_index = luigi.Parameter(description='ElasticSearch index.', default='data')
     es_username = luigi.Parameter(description='ElasticSearch username.', default='pipeline')
     es_password = luigi.Parameter(description='ElasticSearch password.', visibility=ParameterVisibility.PRIVATE, default=None)
@@ -213,7 +214,7 @@ class HailElasticSearchTask(luigi.Task):
             raise Exception(f"Invalid es_index name [{self.es_index}], must be lowercase")
 
         self._es = ElasticsearchClient(
-            host=self.es_host, port=self.es_port, es_username=self.es_username, es_password=self.es_password)
+            host=self.es_host, port=self.es_port, es_username=self.es_username, es_password=self.es_password, es_scheme=self.es_scheme)
 
     def requires(self):
         return [VcfFile(filename=self.source_path)]

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -200,7 +200,7 @@ class HailElasticSearchTask(luigi.Task):
     use_temp_loading_nodes = luigi.BoolParameter(default=True, description='Whether to use temporary loading nodes.')
     es_host = luigi.Parameter(description='ElasticSearch host.', default='localhost')
     es_port = luigi.IntParameter(description='ElasticSearch port.', default=9200)
-    es_scheme = luigi.Parameter(description='ElastisSearch scheme (http or https)', default='http')
+    es_scheme = luigi.Parameter(description='ElasticSearch scheme (http or https)', default='http')
     es_index = luigi.Parameter(description='ElasticSearch index.', default='data')
     es_username = luigi.Parameter(description='ElasticSearch username.', default='pipeline')
     es_password = luigi.Parameter(description='ElasticSearch password.', visibility=ParameterVisibility.PRIVATE, default=None)

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -200,7 +200,7 @@ class HailElasticSearchTask(luigi.Task):
     use_temp_loading_nodes = luigi.BoolParameter(default=True, description='Whether to use temporary loading nodes.')
     es_host = luigi.Parameter(description='ElasticSearch host.', default='localhost')
     es_port = luigi.IntParameter(description='ElasticSearch port.', default=9200)
-    es_scheme = luigi.Parameter(description='ElasticSearch scheme (http or https)', default='http')
+    es_use_ssl = luigi.BoolParameter(description='Use SSL for ElasticSearch', default=False)
     es_index = luigi.Parameter(description='ElasticSearch index.', default='data')
     es_username = luigi.Parameter(description='ElasticSearch username.', default='pipeline')
     es_password = luigi.Parameter(description='ElasticSearch password.', visibility=ParameterVisibility.PRIVATE, default=None)
@@ -214,7 +214,7 @@ class HailElasticSearchTask(luigi.Task):
             raise Exception(f"Invalid es_index name [{self.es_index}], must be lowercase")
 
         self._es = ElasticsearchClient(
-            host=self.es_host, port=self.es_port, es_username=self.es_username, es_password=self.es_password, es_scheme=self.es_scheme)
+            host=self.es_host, port=self.es_port, es_username=self.es_username, es_password=self.es_password, es_use_ssl=self.es_use_ssl)
 
     def requires(self):
         return [VcfFile(filename=self.source_path)]


### PR DESCRIPTION
Tested using:
```
hailctl dataproc submit seqr-loading-cluster seqr_loading.py --pyfiles "lib,../hail_scripts" SeqrMTToESTask --local-scheduler --dest-path gs://cpg-seqr-testing/NA12878_trio/annotated.mt --es-host elasticsearch.es.australia-southeast1.gcp.elastic-cloud.com --es-port 9243 --es-use-ssl --es-username seqr --es-password *** --es-index na12878-trio --es-index-min-num-shards 1 --genome-version 38
```