### PR TITLE
Add pedigree check and HaplotypeCaller

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,8 +25,9 @@
 # 15. logging-not-lazy
 # 16. consider-using-set-comprehension
 # 17. unnecessary-pass
+# 18. no-else-return
 
-disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,C0330,C0326,fixme,logging-fstring-interpolation,import-error,no-member,c-extension-no-member,unsubscriptable-object,R0801,C0302,line-too-long,too-many-locals,too-many-branches,trailing-whitespace,logging-not-lazy,consider-using-set-comprehension,unnecessary-pass
+disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,C0330,C0326,fixme,logging-fstring-interpolation,import-error,no-member,c-extension-no-member,unsubscriptable-object,R0801,C0302,line-too-long,too-many-locals,too-many-branches,trailing-whitespace,logging-not-lazy,consider-using-set-comprehension,unnecessary-pass,no-else-return
 
 # Overriding variable name patterns to allow short 1- or 2-letter variables
 attr-rgx=[a-z_][a-z0-9_]{0,50}$

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ run_test:
 	--dataset seqr \
 	--access-level test \
 	--output-dir "gs://cpg-seqr-test/seqr_$(VERSION)/hail" \
-	--description "test seqr loade - batch small1" \
+	--description "test seqr loader - batch small1" \
 	batch_seqr_loader/batch_workflow.py \
 	--gvcf-bucket gs://cpg-seqr-test/gvcf/small1 \
 	--cram-bucket gs://cpg-seqr-test/cram \
@@ -35,7 +35,7 @@ run_test:
 	--dest-mt-path "gs://cpg-seqr-test/seqr_$(VERSION)/output/annotated.mt" \
 	--genomicsdb-bucket gs://cpg-seqr-test/seqr_$(VERSION)/genomicsdb \
 	--keep-scratch \
-        --reuse
+	--reuse
 
 .PHONY: run_test_extend
 run_test_extend:
@@ -51,4 +51,5 @@ run_test_extend:
 	--work-bucket "gs://cpg-seqr-test/seqr_$(VERSION)/work-withsmall2" \
 	--dest-mt-path "gs://cpg-seqr-test/seqr_$(VERSION)/output/annotated-withsmall2.mt" \
 	--genomicsdb-bucket gs://cpg-seqr-test/seqr_$(VERSION)/genomicsdb \
-	--keep-scratch
+	--keep-scratch \
+	--reuse

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ run_test_extend:
 	--reuse
 
 .PHONY: run_full_family
-run_test:
+run_full_family:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1_1
+VERSION := v1_2
 
 .PHONY: package
 package:
@@ -29,11 +29,10 @@ run_test:
 	--description "test seqr loader - batch small1" \
 	batch_seqr_loader/batch_workflow.py \
 	--gvcf-bucket "gs://cpg-seqr-test/gvcf/small1" \
-	--cram-bucket "gs://cpg-seqr-test/cram" \
-	--dataset seqr \
-	--work-bucket "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/work" \
-	--dest-mt-path "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/output/annotated.mt" \
-	--genomicsdb-bucket "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/genomicsdb" \
+	--cram-bucket "gs://cpg-seqr-test/cram/small1" \
+	--ped-file    "gs://cpg-seqr-test/gvcf/small1/samples.ped" \
+	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--work-bucket "gs://cpg-seqr-test-tmp/work/loader-$(VERSION)/work-small1-cram" \
 	--keep-scratch \
 	--reuse
 
@@ -45,11 +44,24 @@ run_test_extend:
 	--output-dir "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/hail" \
 	--description "test seqr loader - extend with batch small2" \
 	batch_seqr_loader/batch_workflow.py \
-	--gvcf-bucket "gs://cpg-seqr-test/gvcf/small2" \
-	--ped-file "gs://cpg-seqr-test/gvcf/small2/samples.ped" \
+	--gvcf-bucket  "gs://cpg-seqr-test/gvcf/small2" \
+	--ped-file     "gs://cpg-seqr-test/gvcf/small2/samples.ped" \
+	--data-bucket  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--work-bucket  "gs://cpg-seqr-test-tmp/work/loader-$(VERSION)/work-small2" \
+	--keep-scratch \
+	--reuse
+
+.PHONY: run_full_family
+run_test:
+	analysis-runner \
 	--dataset seqr \
-	--work-bucket "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/work-withsmall2" \
-	--dest-mt-path "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/output/annotated-withsmall2.mt" \
-	--genomicsdb-bucket "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/genomicsdb" \
+	--access-level test \
+	--output-dir "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/hail" \
+	--description "test seqr loader - families" \
+	batch_seqr_loader/batch_workflow.py \
+	--gvcf-bucket "gs://cpg-seqr-test/gvcf/families" \
+	--ped-file    "gs://cpg-seqr-test/gvcf/families/samples.ped" \
+	--data-bucket "gs://cpg-seqr-test/data/families-$(VERSION)" \
+	--work-bucket "gs://cpg-seqr-test-tmp/work/loader-$(VERSION)/work-families" \
 	--keep-scratch \
 	--reuse

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ run_test:
 	--work-bucket "gs://cpg-seqr-test/seqr_$(VERSION)/work" \
 	--dest-mt-path "gs://cpg-seqr-test/seqr_$(VERSION)/output/annotated.mt" \
 	--genomicsdb-bucket gs://cpg-seqr-test/seqr_$(VERSION)/genomicsdb \
-	--keep-scratch
+	--keep-scratch \
+        --reuse
 
 .PHONY: run_test_extend
 run_test_extend:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1-0
+VERSION := v1gvcf
 
 .PHONY: package
 package:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v0
+VERSION := v1-0
 
 .PHONY: package
 package:
@@ -29,7 +29,7 @@ run_test:
 	--description "test seqr loade - batch small1" \
 	batch_seqr_loader/batch_workflow.py \
 	--gvcf-bucket gs://cpg-seqr-test/gvcf/small1 \
-	--ped-file gs://cpg-seqr-test/gvcf/small1/samples.ped \
+	--cram-bucket gs://cpg-seqr-test/cram \
 	--dataset seqr \
 	--work-bucket "gs://cpg-seqr-test/seqr_$(VERSION)/work" \
 	--dest-mt-path "gs://cpg-seqr-test/seqr_$(VERSION)/output/annotated.mt" \

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -360,7 +360,10 @@ def _pedigree_checks(
 cat <<EOT >> check_pedigree.py
 {script}
 EOT
-python check_pedigree.py --somalier-prefix {prefix}
+python check_pedigree.py \
+--somalier-samples {relate_j.output_samples} \
+--somalier-pairs {relate_j.somalier_pairs_path} \
+--somalier-html {relate_j.output_html}
     """
     )
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -28,6 +28,7 @@ GATK_CONTAINER = (
     f'australia-southeast1-docker.pkg.dev/cpg-common/images/gatk:{GATK_VERSION}'
 )
 PICARD_CONTAINER = f'us.gcr.io/broad-gotc-prod/picard-cloud:2.23.8'
+BAZAM_CONTAINER = f'australia-southeast1-docker.pkg.dev/fewgenomes/images/bazam:v2'
 
 # Fixed scatter count, because we are storing a genomics DB per each interval
 NUMBER_OF_INTERVALS = 10

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -381,7 +381,7 @@ def _make_genotype_jobs(
     reference: hb.ResourceGroup,
     work_bucket: str,  # pylint: disable=unused-argument
     overwrite: bool,  # pylint: disable=unused-argument
-    depends_on: List[Job],
+    depends_on: Optional[List[Job]],
 ) -> Tuple[List[Job], pd.DataFrame]:
     """
     Takes all samples with a 'file' of 'type'='bam' in `samples_df`,
@@ -698,7 +698,7 @@ def _add_split_intervals_job(
 def _add_haplotype_caller_job(
     b: hb.Batch,
     bam_fpath: str,
-    depends_on: List[Job],
+    depends_on: Optional[List[Job]],
     interval: hb.ResourceFile,
     reference: hb.ResourceGroup,
     sample_name: str,

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -539,24 +539,25 @@ def find_inputs(
                     pass
 
     for input_type, fpaths in found_files_by_type.items():
-        assert input_type in ['gvcf', 'bam', 'cram'], input_type
         for fp in fpaths:
-            if input_type == 'gvcf':
-                index = fp + '.tbi'
+            index = fp + '.tbi'
+            if fp.endswith('.g.vcf.gz'):
                 if not file_exists(index):
                     logger.critical(f'Not found TBI index for file {fp}')
-            elif input_type == 'bam':
+            elif fp.endswith('.bam'):
                 index = fp + '.bai'
                 if not file_exists(index):
                     index = re.sub('.bam$', '.bai', fp)
                     if not file_exists(index):
                         logger.critical(f'Not found BAI index for file {fp}')
-            else:
+            elif fp.endswith('.cram'):
                 index = fp + '.crai'
                 if not file_exists(index):
                     index = re.sub('.cram$', '.crai', fp)
                     if not file_exists(index):
                         logger.critical(f'Not found CRAI index for file {fp}')
+            else:
+                logger.critical(f'Unrecognised input file extention {fp}')
             found_indices_by_type[input_type].append(index)
 
     def _get_base_name(file_path):

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -831,10 +831,11 @@ def _add_import_gvcfs_job(
         untar_genomicsdb_cmd = ''
         job_name = 'Creating GenomicsDB'
 
+        samples_to_add = set(new_samples_df.s)
         samples_to_add_df = new_samples_df
-        samples_will_be_in_db = set(new_samples_df.s)
+        samples_will_be_in_db = samples_to_add
 
-    if not samples_to_add_df:
+    if not samples_to_add:
         return None, samples_will_be_in_db
 
     sample_map_fpath = join(work_bucket, 'work', 'sample_name.csv')

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -594,7 +594,7 @@ def _add_merge_gvcfs_job(
     j.command(
         f"""set -e
     java -Xms{mem_gb - 1}m -jar /usr/picard/picard.jar \
-      MergeVcfs {input_cmd} OUTPUT={j.output_vcf}
+      MergeVcfs {input_cmd} OUTPUT={j.output_gvcf}
       """
     )
     if output_gvcf_path:

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -315,15 +315,18 @@ def _somalier(
     if depends_on:
         j.depends_on(extract_jobs)
 
-    print('Sample names: ' + str(samples_df['s']))
+    print('Sample names: ' + str(list(samples_df['s'])))
     relate_input = b.read_input_group(
-        **{sn: join(fingerprints_bucket, f'{sn}.somalier') for sn in samples_df['s']}
+        **{
+            sn: join(fingerprints_bucket, f'{sn}.somalier')
+            for sn in list(samples_df['s'])
+        }
     )
     j.command(
         f"""set -e
         
         somalier relate \\
-        {' '.join(relate_input)} \\
+        {' '.join(relate_input[sn] for sn in samples_df['s'])} \\
         --ped {ped_file} \\
         -o related
         

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -54,7 +54,8 @@ DATAPROC_PACKAGES = [
 ]
 
 logger = logging.getLogger('seqr-loader')
-logger.setLevel('INFO')
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger.setLevel(logging.INFO)
 
 
 @click.command()
@@ -363,7 +364,7 @@ EOT
 python check_pedigree.py \
 --somalier-samples {relate_j.output_samples} \
 --somalier-pairs {relate_j.output_pairs} \
---somalier-html {relate_j.output_html}
+--somalier-html {somalier_html_path}
     """
     )
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -302,7 +302,7 @@ def _somalier(
                 -f {reference.base} \\
                 {input_file['base']}
                 
-                ln -s extracted/{sn}.somalier {j.output_file}
+                mv extracted/{sn}.somalier {j.output_file}
               """
             )
             b.write_output(j.output_file, fingerprint_file)
@@ -330,10 +330,10 @@ def _somalier(
         --ped {ped_file} \\
         -o related
         
-        ln -s related.html {j.output_html}
-        ln -s related.groups.tsv {j.output_groups}
-        ln -s related.pairs.tsv {j.output_pairs}
-        ln -s related.samples.tsv {j.output_samples}
+        mv related.html {j.output_html}
+        mv related.groups.tsv {j.output_groups}
+        mv related.pairs.tsv {j.output_pairs}
+        mv related.samples.tsv {j.output_samples}
       """
     )
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -315,6 +315,7 @@ def _somalier(
     if depends_on:
         j.depends_on(extract_jobs)
 
+    print('Sample names: ' + str(samples_df['s']))
     relate_input = b.read_input_group(
         **{sn: join(fingerprints_bucket, f'{sn}.somalier') for sn in samples_df['s']}
     )

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -562,7 +562,7 @@ def _add_haplotype_caller_job(
     j = b.new_job('HaplotypeCaller')
     j.image(GATK_CONTAINER)
     j.cpu(2)
-    mem_gb = 16
+    mem_gb = 64
     j.memory(f'{mem_gb}G')
     j.storage(f'{disk_size}G')
     j.declare_resource_group(

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -556,7 +556,7 @@ def _add_haplotype_caller_job(
     disk_size = math.ceil(input_and_output_size / scatter_divisor) + reference_data_size
 
     job_name = 'HaplotypeCaller'
-    if interval_idx:
+    if interval_idx is not None:
         job_name += f', {sample_name} {interval_idx}/{number_of_intervals}'
 
     j = b.new_job('HaplotypeCaller')
@@ -691,7 +691,7 @@ def _add_import_gvcfs_job(
     )
     sample_name_map = b.read_input(sample_map_fpath)
 
-    if interval_idx:
+    if interval_idx is not None:
         job_name += f' {interval_idx}/{number_of_intervals}'
 
     j = b.new_job(job_name)
@@ -755,7 +755,7 @@ def _add_gatk_genotype_gvcf_job(
     Run joint-calling on all samples in a genomics database
     """
     job_name = 'Joint-genotype'
-    if interval_idx:
+    if interval_idx is not None:
         job_name += f' {interval_idx}/{number_of_intervals}'
 
     j = b.new_job(job_name)

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -312,8 +312,7 @@ def _somalier(
     j.image(SOMALIER_CONTAINER)
     j.memory(f'8G')
     j.storage(f'10G')
-    if depends_on:
-        j.depends_on(extract_jobs)
+    j.depends_on(extract_jobs)
 
     print('Sample names: ' + str(list(samples_df['s'])))
     relate_input = b.read_input_group(

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -331,6 +331,7 @@ def _somalier(
         --ped samples.ped \\
         -o related
         
+        ls
         mv related.html {j.output_html}
         mv related.groups.tsv {j.output_groups}
         mv related.pairs.tsv {j.output_pairs}

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -59,11 +59,12 @@ logger.setLevel('INFO')
 )
 @click.option(
     '--bam-bucket',
-    'bam_buckets',
+    '--cram-bucket' 'bam_buckets',
     multiple=True,
 )
 @click.option(
     '--bam-to-realign-bucket',
+    '--cram-to-realign-bucket',
     'bam_to_realign_buckets',
     multiple=True,
 )

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -54,7 +54,7 @@ DATAPROC_PACKAGES = [
 ]
 
 logger = logging.getLogger('seqr-loader')
-logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
 logger.setLevel(logging.INFO)
 
 
@@ -349,7 +349,6 @@ def _pedigree_checks(
     b.write_output(relate_j.output_html, somalier_html_path)
     b.write_output(relate_j.output_samples, somalier_samples_path)
     b.write_output(relate_j.output_pairs, somalier_pairs_path)
-
     check_j = b.new_job(f'Check relatedness and sex')
     check_j.image(PEDDY_CONTAINER)
     check_j.memory(f'8G')
@@ -361,9 +360,9 @@ def _pedigree_checks(
 cat <<EOT >> check_pedigree.py
 {script}
 EOT
-python check_pedigree.py \
---somalier-samples {relate_j.output_samples} \
---somalier-pairs {relate_j.output_pairs} \
+python check_pedigree.py \\
+--somalier-samples {relate_j.output_samples} \\
+--somalier-pairs {relate_j.output_pairs} \\
 --somalier-html {somalier_html_path}
     """
     )
@@ -527,7 +526,7 @@ def find_inputs(
     ped_fpath: Optional[str] = None,
 ) -> pd.DataFrame:  # pylint disable=too-many-branches
     """
-    Read the inputs assuming a standard CPG storage structure.
+    Find input files: GVCFs, BAMs or CRAMs
     :param gvcf_buckets: buckets to find GVCF files
     :param bam_buckets: buckets to find BAM files
         (will be passed to HaplotypeCaller to produce GVCFs)
@@ -1064,13 +1063,15 @@ def can_reuse(fpath: str, overwrite: bool) -> bool:
         return True
 
 
-def hash_sample_names(samples_names: Iterable[str]) -> str:
+def hash_sample_names(sample_names: Iterable[str]) -> str:
     """
     Return a unique hash string from a from a set of strings
-    :param samples_names: set of strings
+    :param sample_names: set of strings
     :return: a string hash
     """
-    return hashlib.sha224(' '.join(sorted(samples_names)).encode()).hexdigest()
+    for sn in sample_names:
+        assert ' ' not in sn, sn
+    return hashlib.sha224(' '.join(sorted(sample_names)).encode()).hexdigest()
 
 
 if __name__ == '__main__':

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -286,7 +286,7 @@ def _somalier(
             j.memory(f'8G')
             j.storage(f'10G')
             if depends_on:
-                j.depends_on(depends_on)
+                j.depends_on(*depends_on)
 
             input_file = b.read_input_group(
                 base=input_path,
@@ -312,7 +312,7 @@ def _somalier(
     j.image(SOMALIER_CONTAINER)
     j.memory(f'8G')
     j.storage(f'10G')
-    j.depends_on(extract_jobs)
+    j.depends_on(*extract_jobs)
 
     print('Sample names: ' + str(list(samples_df['s'])))
     relate_input = b.read_input_group(
@@ -470,7 +470,7 @@ def _make_joint_genotype_jobs(
             output_vcf_path=output_vcf_path,
         )
         if import_gvcfs_job:
-            genotype_vcf_job.depends_on(import_gvcfs_job)
+            genotype_vcf_job.depends_on(*import_gvcfs_job)
 
         genotype_vcf_jobs.append(genotype_vcf_job)
         genotyped_vcfs.append(genotype_vcf_job.output_vcf)
@@ -714,7 +714,7 @@ def _add_haplotype_caller_job(
         }
     )
     if depends_on:
-        j.depends_on(depends_on)
+        j.depends_on(*depends_on)
 
     j.command(
         f"""set -e

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -286,9 +286,9 @@ def _make_genotype_jobs(
             merge_gvcf_jobs.append(b.new_job('Merge GVCFs [reuse]'))
         else:
             if bam_fpath.endswith('.cram'):
-                index_path = bam_fpath.removesuffix('.cram') + '.crai'
+                index_path = os.path.splitext(bam_fpath)[0] + '.crai'
             else:
-                index_path = bam_fpath.removesuffix('.bam') + '.bai'
+                index_path = os.path.splitext(bam_fpath)[0] + '.bai'
             input_bam = b.read_input_group(
                 bam=bam_fpath,
                 bai=index_path,

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -218,6 +218,14 @@ def main(
         )
 
     b = hb.Batch('Seqr loader', backend=backend)
+
+    reference = b.read_input_group(
+        base=REF_FASTA,
+        fai=REF_FASTA + '.fai',
+        dict=REF_FASTA.replace('.fasta', '').replace('.fna', '').replace('.fa', '')
+        + '.dict',
+    )
+
     # realign_bam_jobs = _make_realign_bam_jobs(
     #     b=b,
     #     samples_df=samples_df,

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -381,7 +381,7 @@ def _make_genotype_jobs(
     reference: hb.ResourceGroup,
     work_bucket: str,  # pylint: disable=unused-argument
     overwrite: bool,  # pylint: disable=unused-argument
-    depends_on: Optional[List[Job]],
+    depends_on: Optional[List[Job]] = None,
 ) -> Tuple[List[Job], pd.DataFrame]:
     """
     Takes all samples with a 'file' of 'type'='bam' in `samples_df`,
@@ -411,12 +411,12 @@ def _make_genotype_jobs(
                     _add_haplotype_caller_job(
                         b,
                         bam_fpath,
-                        depends_on=depends_on,
                         interval=intervals[f'interval_{idx}'],
                         reference=reference,
                         sample_name=sn,
                         interval_idx=idx,
                         number_of_intervals=NUMBER_OF_INTERVALS,
+                        depends_on=depends_on,
                     )
                 )
             merge_gvcf_jobs.append(
@@ -698,12 +698,12 @@ def _add_split_intervals_job(
 def _add_haplotype_caller_job(
     b: hb.Batch,
     bam_fpath: str,
-    depends_on: Optional[List[Job]],
     interval: hb.ResourceFile,
     reference: hb.ResourceGroup,
     sample_name: str,
     interval_idx: Optional[int] = None,
     number_of_intervals: int = 1,
+    depends_on: Optional[List[Job]] = None,
 ) -> Job:
     """
     Run HaplotypeCaller on an input BAM or CRAM, and output GVCF

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -399,12 +399,15 @@ def find_inputs(
         for ib in buckets:
             for pattern in patterns:
                 cmd = f"gsutil ls '{join(ib, pattern)}'"
-                found_files_by_type[input_type].extend(
-                    line.strip()
-                    for line in subprocess.check_output(cmd, shell=True)
-                    .decode()
-                    .split()
-                )
+                try:
+                    found_files_by_type[input_type].extend(
+                        line.strip()
+                        for line in subprocess.check_output(cmd, shell=True)
+                        .decode()
+                        .split()
+                    )
+                except subprocess.CalledProcessError:
+                    pass
 
     def _get_base_name(file_path):
         return re.sub('(.bam|.cram|.g.vcf.gz)$', '', os.path.basename(file_path))

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -78,7 +78,6 @@ logger.setLevel('INFO')
 @click.option(
     '--ped-file',
     'ped_fpath',
-    required=True,
 )
 @click.option(
     '--dataset',

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -596,7 +596,7 @@ def find_inputs(
     if ped_fpath:
         local_ped_fpath = join(local_tmp_dir, basename(ped_fpath))
         subprocess.run(
-            f'gsutil cat {ped_fpath} | grep -v ^Family.ID > {local_ped_fpath}',
+            f'gsutil cat {ped_fpath} | cut -f1-6 | grep -v ^Family.ID > {local_ped_fpath}',
             check=False,
             shell=True,
         )
@@ -612,8 +612,8 @@ def find_inputs(
                 'Phenotype',
             ],
         )
-        df = df.set_index('Individual.ID', drop=False)
         df = df.rename(columns={'Individual.ID': 's'})
+        df = df.set_index('s', drop=False)
         ped_snames = list(df['s'])
 
         # Checking that file base names have a 1-to-1 match with the samples in PED

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -59,7 +59,8 @@ logger.setLevel('INFO')
 )
 @click.option(
     '--bam-bucket',
-    '--cram-bucket' 'bam_buckets',
+    '--cram-bucket',
+    'bam_buckets',
     multiple=True,
 )
 @click.option(

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -323,10 +323,12 @@ def _somalier(
     )
     j.command(
         f"""set -e
-        
+
+        cat {ped_file} | grep -v Family.ID > samples.ped 
+
         somalier relate \\
         {' '.join(relate_input[sn] for sn in samples_df['s'])} \\
-        --ped {ped_file} \\
+        --ped samples.ped \\
         -o related
         
         mv related.html {j.output_html}

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -362,7 +362,7 @@ cat <<EOT >> check_pedigree.py
 EOT
 python check_pedigree.py \
 --somalier-samples {relate_j.output_samples} \
---somalier-pairs {relate_j.somalier_pairs_path} \
+--somalier-pairs {relate_j.output_pairs} \
 --somalier-html {relate_j.output_html}
     """
     )

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -325,7 +325,7 @@ def _pedigree_checks(
         cat {ped_file} | grep -v Family.ID > samples.ped 
 
         somalier relate \\
-        {' '.join(j.ouptut_file for j in extract_jobs)} \\
+        {' '.join(j.output_file for j in extract_jobs)} \\
         --ped samples.ped \\
         -o related \\
         --infer

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -333,7 +333,6 @@ def _somalier(
         
         ls
         mv related.html {j.output_html}
-        mv related.groups.tsv {j.output_groups}
         mv related.pairs.tsv {j.output_pairs}
         mv related.samples.tsv {j.output_samples}
       """

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -199,13 +199,13 @@ def main(
     )
     df = pd.read_csv(local_somalier_results, delimiter='\t')
     mismathced = (
-        (df['sex'] == 2 & df['original_pedigree_sex'] != 'female') | 
-        (df['sex'] == 1 & df['original_pedigree_sex'] != 'male')
+        (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female') | 
+        (df['sex'] == 1) & (df['original_pedigree_sex'] != 'male')
     )
     if mismathced.any():
         logger.error(
-            f'Found samples with mismatched sex: {df[mismathced].s}. '
-            f'Review somalier results for more information: {somalier_html_path}'
+            f'Found samples with mismatched sex: {df[mismathced].sample_id}. '
+            f'Review the somalier results for more information: {somalier_html_path}'
         )
         return
         

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -208,9 +208,14 @@ def main(
     if mismathced.any():
         logger.error(
             f'Found samples with mismatched sex: {df[mismathced].sample_id}. '
-            f'Review the somalier results for more information: {somalier_html_path}'
+            f'Review the somalier results for more detail: {somalier_html_path}'
         )
         return
+    else:
+        logger.error(
+            f'All sample sex match the provided one. '
+            f'Review the somalier results for more detail: {somalier_html_path}'
+        )
 
     b = hb.Batch('Seqr loader', backend=backend)
     # realign_bam_jobs = _make_realign_bam_jobs(
@@ -593,7 +598,19 @@ def find_inputs(
         subprocess.run(
             f'gsutil cp {ped_fpath} {local_ped_fpath}', check=False, shell=True
         )
-        df = pd.read_csv(local_ped_fpath, delimiter='\t')
+        df = pd.read_csv(
+            local_ped_fpath,
+            delimiter='\t',
+            comment='Family.ID',
+            names=[
+                'Family.ID',
+                'Individual.ID',
+                'Paternal.ID',
+                'Maternal.ID',
+                'Gender',
+                'Phenotype',
+            ],
+        )
         df = df.set_index('Individual.ID', drop=False)
         df = df.rename(columns={'Individual.ID': 's'})
         ped_snames = list(df['s'])

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -285,9 +285,13 @@ def _make_genotype_jobs(
         if can_reuse(output_gvcf_path, overwrite):
             merge_gvcf_jobs.append(b.new_job('Merge GVCFs [reuse]'))
         else:
+            if bam_fpath.endswith('.cram'):
+                index_path = bam_fpath.removesuffix('.cram') + '.crai'
+            else:
+                index_path = bam_fpath.removesuffix('.bam') + '.bai'
             input_bam = b.read_input_group(
                 bam=bam_fpath,
-                bai=re.sub(re.sub(bam_fpath, '.cram$', '.crai'), '.bam$', '.bai'),
+                bai=index_path,
             )
             haplotype_caller_jobs = []
             for idx in range(NUMBER_OF_INTERVALS):

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -476,7 +476,7 @@ def _make_joint_genotype_jobs(
             output_vcf_path=output_vcf_path,
         )
         if import_gvcfs_job:
-            genotype_vcf_job.depends_on(*import_gvcfs_job)
+            genotype_vcf_job.depends_on(import_gvcfs_job)
 
         genotype_vcf_jobs.append(genotype_vcf_job)
         genotyped_vcfs.append(genotype_vcf_job.output_vcf)

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -15,9 +15,10 @@ import shutil
 import subprocess
 import tempfile
 import hashlib
+import inspect
 from collections import defaultdict
-from os.path import join, basename, dirname
-from typing import Optional, List, Tuple, Dict, Set, Iterable
+from os.path import join, basename, dirname, abspath
+from typing import Optional, List, Tuple, Dict, Set, Iterable, Callable
 import pandas as pd
 import click
 import hailtop.batch as hb
@@ -350,11 +351,17 @@ def _pedigree_checks(
     check_j.image(PEDDY_CONTAINER)
     check_j.memory(f'8G')
     check_j.storage(f'10G')
+    with open(join(dirname(abspath(__file__)), 'check_pedigree.py')) as f:
+        script = f.read()
     check_j.command(
         f"""set -e
-        batch_seqr_loader/check_pedigree.py --somalier-prefix {prefix}
-      """
+cat <<EOT >> check_pedigree.py
+{script}
+EOT
+python check_pedigree.py --somalier-prefix {prefix}
+    """
     )
+
     check_j.depends_on(relate_j)
     return check_j
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -397,12 +397,14 @@ def find_inputs(
     for input_type, buckets in input_buckets_by_type.items():
         patterns = ['*.g.vcf.gz'] if input_type == 'gvcf' else ['*.bam', '*.cram']
         for ib in buckets:
-            path = ' '.join(join(ib, ptn) for ptn in patterns)
-            cmd = f"gsutil ls '{path}'"
-            found_files_by_type[input_type].extend(
-                line.strip()
-                for line in subprocess.check_output(cmd, shell=True).decode().split()
-            )
+            for pattern in patterns:
+                cmd = f"gsutil ls '{join(ib, pattern)}'"
+                found_files_by_type[input_type].extend(
+                    line.strip()
+                    for line in subprocess.check_output(cmd, shell=True)
+                    .decode()
+                    .split()
+                )
 
     def _get_base_name(file_path):
         return re.sub('(.bam|.cram|.g.vcf.gz)$', '', os.path.basename(file_path))

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -596,12 +596,13 @@ def find_inputs(
     if ped_fpath:
         local_ped_fpath = join(local_tmp_dir, basename(ped_fpath))
         subprocess.run(
-            f'gsutil cp {ped_fpath} {local_ped_fpath}', check=False, shell=True
+            f'gsutil cat {ped_fpath} | grep -v ^Family.ID > {local_ped_fpath}',
+            check=False,
+            shell=True,
         )
         df = pd.read_csv(
             local_ped_fpath,
             delimiter='\t',
-            comment='Family.ID',
             names=[
                 'Family.ID',
                 'Individual.ID',

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -15,7 +15,9 @@ import pandas as pd
 import click
 from peddy import Ped
 
-logger = logging.getLogger()
+logger = logging.getLogger('check-pedigree')
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger.setLevel(logging.INFO)
 
 
 @click.command()
@@ -41,7 +43,6 @@ def main(
     somalier_pairs_fpath: str,
     somalier_html_fpath: str,
 ):  # pylint: disable=missing-function-docstring
-
     if somalier_samples_fpath.startswith('gs://'):
         local_tmp_dir = tempfile.mkdtemp()
         subprocess.run(
@@ -51,7 +52,7 @@ def main(
         )
         somalier_pairs_fpath = join(local_tmp_dir, basename(somalier_pairs_fpath))
         somalier_samples_fpath = join(local_tmp_dir, basename(somalier_samples_fpath))
-
+    
     # Checking sex
     df = pd.read_csv(somalier_samples_fpath, delimiter='\t')
     mismatching_sex = (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female') | (
@@ -59,45 +60,44 @@ def main(
     ) & (df['original_pedigree_sex'] != 'male')
 
     if mismatching_sex.any():
-        logger.error(
-            f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. '
-            f'Review the somalier results for more detail: {somalier_html_fpath}'
-        )
-        sys.exit(1)
-    else:
         logger.info(
-            f'All sample sex match the provided one. '
-            f'Review the somalier results for more detail: {somalier_html_fpath}'
+            f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. ' +
+            (f'Review the somalier results for more detail: {somalier_html_fpath}'
+             if somalier_html_fpath else '')
         )
 
     # Checking relatedness
-    related_pairs = set()  # pylint: disable=unused-variable
-    ped = Ped(somalier_samples_fpath)  # pylint: disable=unused-variable
-    for s1, s2 in combinations(ped.samples(), 2):
-        relation = ped.relation(s1, s2)
-        if relation not in [
-            'unrelated',
-            'unknown',
-            'related at unknown level',
-            'mom-dad',
-        ]:
-            related_pairs.add(tuple(sorted([s1.sample_id, s2.sample_id])))
-
-    mismatching_pairs = set()
+    ped = Ped(somalier_samples_fpath)
+    sample_by_id = {s.sample_id: s for s in ped.samples()}
+    mismatching_pairs = []
     df = pd.read_csv(somalier_pairs_fpath, delimiter='\t')
-    for row in df.iterrows():
+    for _, row in df.iterrows():
         s1 = row['#sample_a']
         s2 = row['sample_b']
-        rel = row['relatedness']
-        exp_rel = row['expected_relatedness']
-        if exp_rel > 0.2 and rel < 0.1:
-            mismatching_pairs.add((s1, s2, rel, exp_rel))
+        inferred_rel = row['relatedness']
+        provided_rel = row['expected_relatedness']
+        if (provided_rel > 0.2 and inferred_rel < 0.1 or
+             inferred_rel > 0.2 and provided_rel < 0.1):
+            mismatching_pairs.append(
+                f'{s1}, {s2}, '
+                f'provided relatedness: {provided_rel} '
+                f'({ped.relation(sample_by_id[s1], sample_by_id[s2])}), '
+                f'inferred: {inferred_rel}')
     if mismatching_pairs:
-        logger.error(
-            f'Found sample pairs with mismatched relatedness: {mismatching_pairs}. '
-            f'Review the somalier results for more detail: {somalier_html_fpath}'
-        )
+        logger.info(f'Found sample pairs with mismatched relatedness:')
+        for pair in mismatching_pairs:
+            logger.info(pair)
+        if somalier_html_fpath:
+            logger.info(f'Review the somalier results for more detail: {somalier_html_fpath}')
+    
+    if mismatching_sex.any() or mismatching_pairs:
         sys.exit(1)
+    
+    logger.info(
+        f'\nInferred sex and pedigree matches for all samples with the data in the PED file. ' +
+        (f'Review the somalier results for more detail: {somalier_html_fpath}'
+         if somalier_html_fpath else '')
+    )
 
 
 if __name__ == '__main__':

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+"""
+This script parses `somalier relate` (https://github.com/brentp/somalier) outputs,
+and returns a non-zero code if either sex or pedigree is mismatching
+"""
+
+import logging
+import subprocess
+import sys
+import tempfile
+from itertools import combinations
+from os.path import join, basename
+import pandas as pd
+import click
+from peddy import Ped
+
+logger = logging.getLogger()
+
+
+@click.command()
+@click.option(
+    '--somalier-prefix',
+    'somalier_prefix',
+    required=True,
+    help='Prefix to somalier output files, with required {prefix}.pairs.tsv',
+)
+@click.option('--local-tmp-dir', 'local_tmp_dir')
+def main(
+    somalier_prefix: str,
+    local_tmp_dir: str,
+):  # pylint: disable=missing-function-docstring
+
+    somalier_pairs_tsv_path = f'{somalier_prefix}.pairs.tsv'
+    somalier_samples_tsv_path = f'{somalier_prefix}.samples.tsv'
+    somalier_html_path = f'{somalier_prefix}.html'
+
+    if somalier_prefix.startswith('gs://'):
+        local_tmp_dir = local_tmp_dir or tempfile.mkdtemp()
+        subprocess.run(
+            f'gsutil cp {somalier_samples_tsv_path} {somalier_pairs_tsv_path} {local_tmp_dir}/',
+            check=False,
+            shell=True,
+        )
+        somalier_pairs_tsv_path = join(local_tmp_dir, basename(somalier_pairs_tsv_path))
+        somalier_samples_tsv_path = join(
+            local_tmp_dir, basename(somalier_samples_tsv_path)
+        )
+
+    # Checking sex
+    df = pd.read_csv(somalier_samples_tsv_path, delimiter='\t')
+    mismatching_sex = (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female') | (
+        df['sex'] == 1
+    ) & (df['original_pedigree_sex'] != 'male')
+
+    if mismatching_sex.any():
+        logger.error(
+            f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. '
+            f'Review the somalier results for more detail: {somalier_html_path}'
+        )
+        sys.exit(1)
+    else:
+        logger.info(
+            f'All sample sex match the provided one. '
+            f'Review the somalier results for more detail: {somalier_html_path}'
+        )
+
+    # Checking relatedness
+    related_pairs = set()  # pylint: disable=unused-variable
+    ped = Ped(somalier_samples_tsv_path)  # pylint: disable=unused-variable
+    for s1, s2 in combinations(ped.samples(), 2):
+        relation = ped.relation(s1, s2)
+        if relation not in [
+            'unrelated',
+            'unknown',
+            'related at unknown level',
+            'mom-dad',
+        ]:
+            related_pairs.add(tuple(sorted([s1.sample_id, s2.sample_id])))
+
+    mismatching_pairs = set()
+    df = pd.read_csv(somalier_pairs_tsv_path, delimiter='\t')
+    for row in df.iterrows():
+        s1 = row['#sample_a']
+        s2 = row['sample_b']
+        rel = row['relatedness']
+        exp_rel = row['expected_relatedness']
+        if exp_rel > 0.2 and rel < 0.1:
+            mismatching_pairs.add((s1, s2, rel, exp_rel))
+    if mismatching_pairs:
+        logger.error(
+            f'Found sample pairs with mismatched relatedness: {mismatching_pairs}. '
+            f'Review the somalier results for more detail: {somalier_html_path}'
+        )
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=E1120

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -4,12 +4,14 @@
 This script parses `somalier relate` (https://github.com/brentp/somalier) outputs,
 and returns a non-zero code if either sex or pedigree is mismatching
 """
-
+import contextlib
 import logging
 import subprocess
 import sys
 import tempfile
 from os.path import join, basename
+from typing import Dict, List
+
 import pandas as pd
 import click
 from peddy import Ped
@@ -52,23 +54,26 @@ def main(
         somalier_pairs_fpath = join(local_tmp_dir, basename(somalier_pairs_fpath))
         somalier_samples_fpath = join(local_tmp_dir, basename(somalier_samples_fpath))
 
-    # Checking sex
+    logger.info('* Checking sex *')
     df = pd.read_csv(somalier_samples_fpath, delimiter='\t')
-    mismatching_sex = (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female') | (
-        df['sex'] == 1
-    ) & (df['original_pedigree_sex'] != 'male')
+    mismatching_female = (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female')
+    mismatching_male = (df['sex'] == 1) & (df['original_pedigree_sex'] != 'male')
+    mismatching_sex = mismatching_female | mismatching_male
 
     if mismatching_sex.any():
-        logger.info(
-            f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. '
-            + (
-                f'Review the somalier results for more detail: {somalier_html_fpath}'
-                if somalier_html_fpath
-                else ''
+        logger.info(f'Found samples with mismatched sex:')
+        for _, row in df[mismatching_sex].iterrows():
+            inferred_sex = {1: 'male', 2: 'female'}[row.sex]
+            logger.info(
+                f'\t{row.sample_id} (provided: {row.original_pedigree_sex}, inferred: {inferred_sex})'
             )
-        )
+        if somalier_html_fpath:
+            logger.info(
+                f'Review the somalier results for more detail: {somalier_html_fpath}'
+            )
+        logger.info('-' * 10)
 
-    # Checking relatedness
+    logger.info('* Checking relatedness *')
     ped = Ped(somalier_samples_fpath)
     sample_by_id = {s.sample_id: s for s in ped.samples()}
     mismatching_pairs = []
@@ -76,24 +81,34 @@ def main(
     for _, row in df.iterrows():
         s1 = row['#sample_a']
         s2 = row['sample_b']
-        inferred_rel = row['relatedness']
-        provided_rel = row['expected_relatedness']
-        if (
-            provided_rel > 0.2
-            and inferred_rel < 0.1
-            or inferred_rel > 0.2
-            and provided_rel < 0.1
-        ):
+        inferred_rel = infer_relationship(row['relatedness'], row['ibs0'], row['ibs2'])
+        # Supressing all logging output from peddy as it would clutter the logs
+        with contextlib.redirect_stderr(None):
+            with contextlib.redirect_stdout(None):
+                provided_rel = ped.relation(sample_by_id[s1], sample_by_id[s2])
+
+        provided_to_inferred: Dict[str, List[str]] = {
+            'unrelated': ['unrelated'],
+            'related at unknown level': ['unrelated'],  # e.g. mom-dad
+            'mom-dad': ['unrelated'],
+            'parent-child': ['parent-child'],
+            'grandchild': ['below_first_degree'],
+            'niece/nephew': ['below_first_degree'],
+            'great-grandchild': ['below_first_degree'],
+            'cousins': ['below_first_degree'],
+            'full siblings': ['siblings'],
+            'siblings': ['siblings'],
+            'unknown': [],
+        }
+        if inferred_rel not in provided_to_inferred[provided_rel]:
             mismatching_pairs.append(
-                f'{s1}, {s2}, '
-                f'provided relatedness: {provided_rel} '
-                f'({ped.relation(sample_by_id[s1], sample_by_id[s2])}), '
-                f'inferred: {inferred_rel}'
+                f'{s1}-{s2}, '
+                f'provided relationship: "{provided_rel}", inferred: "{inferred_rel}"'
             )
     if mismatching_pairs:
         logger.info(f'Found sample pairs with mismatched relatedness:')
         for pair in mismatching_pairs:
-            logger.info(pair)
+            logger.info(f'\t{pair}')
         if somalier_html_fpath:
             logger.info(
                 f'Review the somalier results for more detail: {somalier_html_fpath}'
@@ -110,6 +125,28 @@ def main(
             else ''
         )
     )
+
+
+def infer_relationship(coeff: float, ibs0: float, ibs2: float) -> str:
+    """
+    Inferres relashionship labels based on the kin coefficient
+    and ibs0 and ibs2 values.
+    """
+    result = 'ambiguous'
+    if coeff < 0.05:
+        result = 'unrelated'
+    elif 0.1 < coeff < 0.38:
+        result = 'below_first_degree'
+    elif 0.38 <= coeff <= 0.62:
+        if ibs0 / ibs2 < 0.005:
+            result = 'parent-child'
+        elif 0.015 < ibs0 / ibs2 < 0.052:
+            result = 'siblings'
+        else:
+            result = 'first_degree'
+    elif coeff > 0.8:
+        result = 'duplicate_or_twins'
+    return result
 
 
 if __name__ == '__main__':

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -20,35 +20,40 @@ logger = logging.getLogger()
 
 @click.command()
 @click.option(
-    '--somalier-prefix',
-    'somalier_prefix',
+    '--somalier-samples',
+    'somalier_samples_fpath',
     required=True,
-    help='Prefix to somalier output files, with required {prefix}.pairs.tsv',
+    help='Path to somalier {prefix}.samples.tsv output file',
 )
-@click.option('--local-tmp-dir', 'local_tmp_dir')
+@click.option(
+    '--somalier-pairs',
+    'somalier_pairs_fpath',
+    required=True,
+    help='Path to somalier {prefix}.pairs.tsv output file',
+)
+@click.option(
+    '--somalier-html',
+    'somalier_html_fpath',
+    help='Path to somalier {prefix}.html output file',
+)
 def main(
-    somalier_prefix: str,
-    local_tmp_dir: str,
+    somalier_samples_fpath: str,
+    somalier_pairs_fpath: str,
+    somalier_html_fpath: str,
 ):  # pylint: disable=missing-function-docstring
 
-    somalier_pairs_tsv_path = f'{somalier_prefix}.pairs.tsv'
-    somalier_samples_tsv_path = f'{somalier_prefix}.samples.tsv'
-    somalier_html_path = f'{somalier_prefix}.html'
-
-    if somalier_prefix.startswith('gs://'):
-        local_tmp_dir = local_tmp_dir or tempfile.mkdtemp()
+    if somalier_samples_fpath.startswith('gs://'):
+        local_tmp_dir = tempfile.mkdtemp()
         subprocess.run(
-            f'gsutil cp {somalier_samples_tsv_path} {somalier_pairs_tsv_path} {local_tmp_dir}/',
+            f'gsutil cp {somalier_samples_fpath} {somalier_pairs_fpath} {local_tmp_dir}/',
             check=False,
             shell=True,
         )
-        somalier_pairs_tsv_path = join(local_tmp_dir, basename(somalier_pairs_tsv_path))
-        somalier_samples_tsv_path = join(
-            local_tmp_dir, basename(somalier_samples_tsv_path)
-        )
+        somalier_pairs_fpath = join(local_tmp_dir, basename(somalier_pairs_fpath))
+        somalier_samples_fpath = join(local_tmp_dir, basename(somalier_samples_fpath))
 
     # Checking sex
-    df = pd.read_csv(somalier_samples_tsv_path, delimiter='\t')
+    df = pd.read_csv(somalier_samples_fpath, delimiter='\t')
     mismatching_sex = (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female') | (
         df['sex'] == 1
     ) & (df['original_pedigree_sex'] != 'male')
@@ -56,18 +61,18 @@ def main(
     if mismatching_sex.any():
         logger.error(
             f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. '
-            f'Review the somalier results for more detail: {somalier_html_path}'
+            f'Review the somalier results for more detail: {somalier_html_fpath}'
         )
         sys.exit(1)
     else:
         logger.info(
             f'All sample sex match the provided one. '
-            f'Review the somalier results for more detail: {somalier_html_path}'
+            f'Review the somalier results for more detail: {somalier_html_fpath}'
         )
 
     # Checking relatedness
     related_pairs = set()  # pylint: disable=unused-variable
-    ped = Ped(somalier_samples_tsv_path)  # pylint: disable=unused-variable
+    ped = Ped(somalier_samples_fpath)  # pylint: disable=unused-variable
     for s1, s2 in combinations(ped.samples(), 2):
         relation = ped.relation(s1, s2)
         if relation not in [
@@ -79,7 +84,7 @@ def main(
             related_pairs.add(tuple(sorted([s1.sample_id, s2.sample_id])))
 
     mismatching_pairs = set()
-    df = pd.read_csv(somalier_pairs_tsv_path, delimiter='\t')
+    df = pd.read_csv(somalier_pairs_fpath, delimiter='\t')
     for row in df.iterrows():
         s1 = row['#sample_a']
         s2 = row['sample_b']
@@ -90,7 +95,7 @@ def main(
     if mismatching_pairs:
         logger.error(
             f'Found sample pairs with mismatched relatedness: {mismatching_pairs}. '
-            f'Review the somalier results for more detail: {somalier_html_path}'
+            f'Review the somalier results for more detail: {somalier_html_fpath}'
         )
         sys.exit(1)
 

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -9,14 +9,13 @@ import logging
 import subprocess
 import sys
 import tempfile
-from itertools import combinations
 from os.path import join, basename
 import pandas as pd
 import click
 from peddy import Ped
 
 logger = logging.getLogger('check-pedigree')
-logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
 logger.setLevel(logging.INFO)
 
 
@@ -52,7 +51,7 @@ def main(
         )
         somalier_pairs_fpath = join(local_tmp_dir, basename(somalier_pairs_fpath))
         somalier_samples_fpath = join(local_tmp_dir, basename(somalier_samples_fpath))
-    
+
     # Checking sex
     df = pd.read_csv(somalier_samples_fpath, delimiter='\t')
     mismatching_sex = (df['sex'] == 2) & (df['original_pedigree_sex'] != 'female') | (
@@ -61,9 +60,12 @@ def main(
 
     if mismatching_sex.any():
         logger.info(
-            f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. ' +
-            (f'Review the somalier results for more detail: {somalier_html_fpath}'
-             if somalier_html_fpath else '')
+            f'Found samples with mismatched sex: {df[mismatching_sex].sample_id}. '
+            + (
+                f'Review the somalier results for more detail: {somalier_html_fpath}'
+                if somalier_html_fpath
+                else ''
+            )
         )
 
     # Checking relatedness
@@ -76,27 +78,37 @@ def main(
         s2 = row['sample_b']
         inferred_rel = row['relatedness']
         provided_rel = row['expected_relatedness']
-        if (provided_rel > 0.2 and inferred_rel < 0.1 or
-             inferred_rel > 0.2 and provided_rel < 0.1):
+        if (
+            provided_rel > 0.2
+            and inferred_rel < 0.1
+            or inferred_rel > 0.2
+            and provided_rel < 0.1
+        ):
             mismatching_pairs.append(
                 f'{s1}, {s2}, '
                 f'provided relatedness: {provided_rel} '
                 f'({ped.relation(sample_by_id[s1], sample_by_id[s2])}), '
-                f'inferred: {inferred_rel}')
+                f'inferred: {inferred_rel}'
+            )
     if mismatching_pairs:
         logger.info(f'Found sample pairs with mismatched relatedness:')
         for pair in mismatching_pairs:
             logger.info(pair)
         if somalier_html_fpath:
-            logger.info(f'Review the somalier results for more detail: {somalier_html_fpath}')
-    
+            logger.info(
+                f'Review the somalier results for more detail: {somalier_html_fpath}'
+            )
+
     if mismatching_sex.any() or mismatching_pairs:
         sys.exit(1)
-    
+
     logger.info(
-        f'\nInferred sex and pedigree matches for all samples with the data in the PED file. ' +
-        (f'Review the somalier results for more detail: {somalier_html_fpath}'
-         if somalier_html_fpath else '')
+        f'\nInferred sex and pedigree matches for all samples with the data in the PED file. '
+        + (
+            f'Review the somalier results for more detail: {somalier_html_fpath}'
+            if somalier_html_fpath
+            else ''
+        )
     )
 
 

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -1,0 +1,214 @@
+"""
+Provides find_inputs function that finds input files (.g.vcf.gz, .bam or .cram) 
+in provided buckets, along with corresponding indices (tbi, bai, crai).
+Compares sample names to the provided PED, and returns DataFrame.
+"""
+
+import logging
+import os
+import re
+import subprocess
+from os.path import join, basename
+from typing import Optional, List, Dict
+import pandas as pd
+from utils import file_exists
+
+logger = logging.getLogger(__file__)
+logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
+logger.setLevel(logging.INFO)
+
+
+def find_inputs(
+    gvcf_buckets: List[str],
+    bam_buckets: List[str],
+    bam_to_realign_buckets: List[str],
+    local_tmp_dir: str,
+    ped_fpath: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Find input files (.g.vcf.gz, .bam or .cram) in provided buckets,
+    along with corresponding indices (tbi, bai, crai).
+    Compares sample names to the provided PED, and returns DataFrame.
+    :param gvcf_buckets: buckets to find GVCF files
+    :param bam_buckets: buckets to find BAM files
+        (will be passed to HaplotypeCaller to produce GVCFs)
+    :param bam_to_realign_buckets: buckets to find BAM files
+        (will be re-aligned with BWA before passing to HaplotypeCaller)
+    :param ped_fpath: pedigree file
+    :param local_tmp_dir: temporary local directory
+    :return: a DataFrame with the pedigree information and paths to input files.
+        Columns: s, file, index, type
+    """
+    input_buckets_by_type = dict(
+        gvcf=gvcf_buckets,
+        bam=bam_buckets,
+        bam_to_realign=bam_to_realign_buckets,
+    )
+    found_files_by_type = _find_files_by_type(input_buckets_by_type)
+    found_indices_by_type = _find_file_indices(found_files_by_type)
+
+    if ped_fpath:
+        # PED file provided, so creating DataFrame based on sample names in the file,
+        # and comparing to found input files
+        df = _df_based_on_ped_file(
+            ped_fpath,
+            found_files_by_type,
+            found_indices_by_type,
+            local_tmp_dir,
+        )
+
+    else:
+        # PED file not provided, so creating DataFrame purely from the found input files
+        data: Dict[str, List] = dict(s=[], file=[], type=[])
+        for input_type in found_files_by_type:
+            for fp, index in zip(
+                found_files_by_type[input_type], found_indices_by_type[input_type]
+            ):
+                data['s'].append(_get_file_base_name(fp))
+                data['file'].append(fp)
+                data['index'].append(index)
+                data['type'].append(input_type)
+
+        df = pd.DataFrame(data=data).set_index('s', drop=False)
+
+    return df
+
+
+def _find_files_by_type(
+    input_buckets_by_type: Dict[str, List[str]]
+) -> Dict[str, List[str]]:
+    """
+    Finds input files like .g.vcf.gz, .bam, .cram
+    """
+    found_files_by_type: Dict[str, List[str]] = {t: [] for t in input_buckets_by_type}
+    for input_type, buckets in input_buckets_by_type.items():
+        patterns = ['*.g.vcf.gz'] if input_type == 'gvcf' else ['*.bam', '*.cram']
+        for ib in buckets:
+            for pattern in patterns:
+                cmd = f"gsutil ls '{join(ib, pattern)}'"
+                try:
+                    found_files_by_type[input_type].extend(
+                        line.strip()
+                        for line in subprocess.check_output(cmd, shell=True)
+                        .decode()
+                        .split()
+                    )
+                except subprocess.CalledProcessError:
+                    pass
+    return found_files_by_type
+
+
+def _find_file_indices(
+    found_files_by_type: Dict[str, List[str]]
+) -> Dict[str, List[str]]:
+    """
+    Finds corresponding index files ('.tbi' for '.g.vcf.gz', '.crai' for '.cram', etc)
+    """
+    found_indices_by_type: Dict[str, List[str]] = {t: [] for t in found_files_by_type}
+    for input_type, fpaths in found_files_by_type.items():
+        for fp in fpaths:
+            index = fp + '.tbi'
+            if fp.endswith('.g.vcf.gz'):
+                if not file_exists(index):
+                    logger.critical(f'Not found TBI index for file {fp}')
+            elif fp.endswith('.bam'):
+                index = fp + '.bai'
+                if not file_exists(index):
+                    index = re.sub('.bam$', '.bai', fp)
+                    if not file_exists(index):
+                        logger.critical(f'Not found BAI index for file {fp}')
+            elif fp.endswith('.cram'):
+                index = fp + '.crai'
+                if not file_exists(index):
+                    index = re.sub('.cram$', '.crai', fp)
+                    if not file_exists(index):
+                        logger.critical(f'Not found CRAI index for file {fp}')
+            else:
+                logger.critical(f'Unrecognised input file extention {fp}')
+            found_indices_by_type[input_type].append(index)
+    return found_indices_by_type
+
+
+def _df_based_on_ped_file(
+    ped_fpath: str,
+    found_files_by_type: Dict[str, List[str]],
+    found_indices_by_type: Dict[str, List[str]],
+    local_tmp_dir: str,
+) -> pd.DataFrame:
+    """
+    Compares found input files to the samples provided in the PED file.
+    Creates an input DataFrame using the PED file as a base.
+    """
+    local_sample_list_fpath = join(local_tmp_dir, basename(ped_fpath))
+    subprocess.run(
+        f'gsutil cat {ped_fpath} | grep -v ^Family.ID | cut -f2 > {local_sample_list_fpath}',
+        check=False,
+        shell=True,
+    )
+    df = pd.read_csv(
+        local_sample_list_fpath,
+        delimiter='\t',
+        names=['s'],
+    ).set_index('s', drop=False)
+    ped_snames = list(df['s'])
+
+    # Checking that file base names have a 1-to-1 match with the samples in PED
+    # First, checking the match of PED sample names to input files
+    all_input_snames = []
+    for fpaths in found_files_by_type.values():
+        all_input_snames.extend([_get_file_base_name(fp) for fp in fpaths])
+
+    mismatches_with_ped_found = False
+
+    for ped_sname in ped_snames:
+        matching_files = [
+            input_sname for input_sname in all_input_snames if ped_sname == input_sname
+        ]
+        if len(matching_files) > 1:
+            logging.warning(
+                f'Multiple input files found for the sample {ped_sname}:'
+                f'{matching_files}'
+            )
+            mismatches_with_ped_found = True
+        elif len(matching_files) == 0:
+            logging.warning(f'No files found for the sample {ped_sname}')
+            mismatches_with_ped_found = True
+
+    # Second, checking the match of input files to PED sample names, and filling a dict
+    for input_type in found_files_by_type:
+        for fp, index in zip(
+            found_files_by_type[input_type], found_indices_by_type[input_type]
+        ):
+            input_sname = _get_file_base_name(fp)
+            matching_sn = [sn for sn in ped_snames if sn == input_sname]
+            if len(matching_sn) > 1:
+                logging.warning(
+                    f'Multiple samples found for the input {input_sname}:'
+                    f'{matching_sn}'
+                )
+                mismatches_with_ped_found = True
+            elif len(matching_sn) == 0:
+                logging.warning(f'No samples found for the input {input_sname}')
+                mismatches_with_ped_found = True
+            else:
+                df.loc[matching_sn[0], 'type'] = input_type
+                df.loc[matching_sn[0], 'file'] = fp
+                df.loc[matching_sn[0], 'index'] = index
+
+    if mismatches_with_ped_found:
+        logging.critical(
+            'Mismatches found between provided input bucket contents, '
+            'and the provided PED file. Make sure all files in the buckets are '
+            'named after sample names in the PED file as '
+            '{sample}.cram, {sample}.g.vcf.gz, etc'
+        )
+    df = df[df.file.notnull()]
+    return df
+
+
+def _get_file_base_name(file_path):
+    """
+    Strips directory path and extention from a file name. Effectively extractss
+    assumed sample name (i.e. assumes file named as gs://path/to/{sample}.g.vcf.gz)
+    """
+    return re.sub('(.bam|.cram|.g.vcf.gz)$', '', os.path.basename(file_path))

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -78,7 +78,7 @@ def _find_files_by_type(
     input_buckets_by_type: Dict[str, List[str]]
 ) -> Dict[str, List[str]]:
     """
-    Finds input files like .g.vcf.gz, .bam, .cram
+    Find input files like .g.vcf.gz, .bam, .cram
     """
     found_files_by_type: Dict[str, List[str]] = {t: [] for t in input_buckets_by_type}
     for input_type, buckets in input_buckets_by_type.items():
@@ -102,7 +102,10 @@ def _find_file_indices(
     found_files_by_type: Dict[str, List[str]]
 ) -> Dict[str, List[str]]:
     """
-    Finds corresponding index files ('.tbi' for '.g.vcf.gz', '.crai' for '.cram', etc)
+    Find corresponding index files. Will look for:
+    '<sample>.g.vcf.gz.tbi' for '<sample>.g.vcf.gz',
+    '<sample>.bam.bai' or '<sample>.bai' for '<sample>.bam',
+    '<sample>.cram.crai' or '<sample>.crai' for '<sample>.cram',
     """
     found_indices_by_type: Dict[str, List[str]] = {t: [] for t in found_files_by_type}
     for input_type, fpaths in found_files_by_type.items():

--- a/batch_seqr_loader/seqr_load.py
+++ b/batch_seqr_loader/seqr_load.py
@@ -17,7 +17,7 @@ from hail_scripts.v02.utils.elasticsearch_client import ElasticsearchClient
 
 logger = logging.getLogger()
 
-SEQR_REF_BUCKET = 'gs://seqr-reference-data'
+SEQR_REF_BUCKET = 'gs://cpg-seqr-reference-data'
 
 
 @click.command()

--- a/batch_seqr_loader/seqr_load.py
+++ b/batch_seqr_loader/seqr_load.py
@@ -15,7 +15,9 @@ import hail as hl
 from lib.model.seqr_mt_schema import SeqrVariantsAndGenotypesSchema
 from hail_scripts.v02.utils.elasticsearch_client import ElasticsearchClient
 
-logger = logging.getLogger()
+logger = logging.getLogger('seqr-load')
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger.setLevel(logging.INFO)
 
 SEQR_REF_BUCKET = 'gs://cpg-seqr-reference-data'
 

--- a/batch_seqr_loader/utils.py
+++ b/batch_seqr_loader/utils.py
@@ -1,0 +1,29 @@
+"""
+Utility functions for the seqr loader
+"""
+
+import os
+from google.cloud import storage
+
+
+def file_exists(path: str) -> bool:
+    """
+    Check if the object exists, where the object can be:
+        * local file
+        * local directory
+        * Google Storage object
+        * Google Storage URL representing a *.mt or *.ht Hail data,
+          in which case it will check for the existence of a
+          *.mt/_SUCCESS or *.ht/_SUCCESS file.
+    :param path: path to the file/directory/object/mt/ht
+    :return: True if the object exists
+    """
+    if path.startswith('gs://'):
+        bucket = path.replace('gs://', '').split('/')[0]
+        path = path.replace('gs://', '').split('/', maxsplit=1)[1]
+        path = path.rstrip('/')  # '.mt/' -> '.mt'
+        if any(path.endswith(f'.{suf}') for suf in ['mt', 'ht']):
+            path = os.path.join(path, '_SUCCESS')
+        gs = storage.Client()
+        return gs.get_bucket(bucket).get_blob(path)
+    return os.path.exists(path)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
     package_dir={'lib': 'luigi_pipeline/lib', 'lib.model': 'luigi_pipeline/lib/model'},
     include_package_data=True,
     zip_safe=False,
-    scripts=['batch_seqr_loader/seqr_load.py'],
     keywords='bioinformatics',
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
* Adds Somalier to infer relationships and sex, and compare that to provided PED file. Example of a run with failing pedigree checks: https://batch.hail.populationgenomics.org.au/batches/2765
* Workflow supports 2 kinds of inputs: `--gvcf-bucket` and `--bam-bucket/--cram-bucket`. Input BAMs and CRAMs would trigger `gatk HaplotypeCaller` to produce GVCFs. Also added `--bam-to-realign-bucket` that would trigger a BWA job, which is not implemented yet.
