### PR TITLE
Loading pipeline updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ run_test:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
 	--version     $(TEST_VERSION) \
-	--dataset     "BB01-BB02" \
+	--seqr-dataset     "BB01-BB02" \
 	--gvcf-bucket "gs://cpg-seqr-test/batches/BB01" \
 	--ped-file    "gs://cpg-seqr-test/batches/BB01/BB01.ped" \
 	--keep-scratch \
@@ -46,7 +46,7 @@ run_test_extend:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
 	--version     $(TEST_VERSION) \
-	--dataset     "BB01-BB02" \
+	--seqr-dataset     "BB01-BB02" \
 	--gvcf-bucket "gs://cpg-seqr-test/batches/BB02" \
 	--ped-file    "gs://cpg-seqr-test/batches/BB02/BB02.ped" \
 	--keep-scratch \
@@ -62,7 +62,7 @@ run_test_mismatched:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
 	--version     $(TEST_VERSION) \
-	--dataset     "BB01-BB02-mismatched" \
+	--seqr-dataset     "BB01-BB02-mismatched" \
 	--gvcf-bucket "gs://cpg-seqr-test/batches/BB01" \
 	--ped-file    "gs://cpg-seqr-test/batches/BB01/BB01-mismatched.ped" \
 	--keep-scratch \
@@ -78,7 +78,7 @@ run_test_cram:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
 	--version     $(TEST_VERSION) \
-	--dataset     "NA12878-cram" \
+	--seqr-dataset     "NA12878-cram" \
 	--cram-bucket "gs://cpg-seqr-test/batches/NA12878-cram" \
 	--keep-scratch \
 	--reuse
@@ -93,7 +93,7 @@ run_zornitza-stark:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
 	--version     "v1-0" \
-	--dataset     "zornitza-stark" \
+	--seqr-dataset     "zornitza-stark" \
 	--bam-bucket  "gs://cpg-seqr-upload-zornitza-stark" \
 	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute-fixed.ped" \
 	--reuse
@@ -108,7 +108,7 @@ run_zornitza-stark-kccg-gvcf:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
 	--version     "v1-0" \
-	--dataset     "zornitza-stark-kccg-gvcf" \
+	--seqr-dataset     "zornitza-stark-kccg-gvcf" \
 	--gvcf-bucket "gs://cpg-seqr-upload-zornitza-stark" \
 	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute-fixed.ped" \
 	--reuse

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ run_test:
 	--description "test seqr loader - test" \
 	batch_seqr_loader/batch_workflow.py \
 	--namespace   test \
-	--dataset     "BB01-BB02" \
 	--version     $(TEST_VERSION) \
-	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
-	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01.ped" \
+	--dataset     "BB01-BB02" \
+	--gvcf-bucket "gs://cpg-seqr-test/batches/BB01" \
+	--ped-file    "gs://cpg-seqr-test/batches/BB01/BB01.ped" \
 	--keep-scratch \
 	--reuse
 
@@ -47,8 +47,8 @@ run_test_extend:
 	--namespace   test \
 	--version     $(TEST_VERSION) \
 	--dataset     "BB01-BB02" \
-	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB02" \
-	--ped-file    "gs://cpg-seqr-test/datasets/BB02/BB02.ped" \
+	--gvcf-bucket "gs://cpg-seqr-test/batches/BB02" \
+	--ped-file    "gs://cpg-seqr-test/batches/BB02/BB02.ped" \
 	--keep-scratch \
 	--reuse
 
@@ -63,8 +63,8 @@ run_test_mismatched:
 	--namespace   test \
 	--version     $(TEST_VERSION) \
 	--dataset     "BB01-BB02-mismatched" \
-	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB02" \
-	--ped-file    "gs://cpg-seqr-test/datasets/BB02/BB02-mismatched.ped" \
+	--gvcf-bucket "gs://cpg-seqr-test/batches/BB01" \
+	--ped-file    "gs://cpg-seqr-test/batches/BB01/BB01-mismatched.ped" \
 	--keep-scratch \
 	--reuse
 
@@ -79,7 +79,7 @@ run_test_cram:
 	--namespace   test \
 	--version     $(TEST_VERSION) \
 	--dataset     "NA12878-cram" \
-	--cram-bucket "gs://cpg-seqr-test/datasets/NA12878-cram" \
+	--cram-bucket "gs://cpg-seqr-test/batches/NA12878-cram" \
 	--keep-scratch \
 	--reuse
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1-0
+TEST_VERSION := v1-0
 
 .PHONY: package
 package:
@@ -25,14 +25,14 @@ run_test:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--output-dir  "gs://cpg-seqr-test-tmp/hail" \
 	--description "test seqr loader - test" \
 	batch_seqr_loader/batch_workflow.py \
-	--namespace test \
+	--namespace   test \
+	--dataset     "BB01-BB02" \
+	--version     $(TEST_VERSION) \
 	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
 	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01.ped" \
-	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
-	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)" \
 	--keep-scratch \
 	--reuse
 
@@ -41,14 +41,14 @@ run_test_extend:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--output-dir  "gs://cpg-seqr-test-tmp/hail" \
 	--description "test seqr loader - extend" \
 	batch_seqr_loader/batch_workflow.py \
-	--namespace test \
+	--namespace   test \
+	--version     $(TEST_VERSION) \
+	--dataset     "BB01-BB02" \
 	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB02" \
 	--ped-file    "gs://cpg-seqr-test/datasets/BB02/BB02.ped" \
-	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
-	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)-extend" \
 	--keep-scratch \
 	--reuse
 
@@ -57,14 +57,29 @@ run_test_mismatched:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--output-dir  "gs://cpg-seqr-test-tmp/hail" \
 	--description "test seqr loader - mismatched" \
 	batch_seqr_loader/batch_workflow.py \
-	--namespace test \
-	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
-	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01-mismatched.ped" \
-	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
-	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)-mismatched" \
+	--namespace   test \
+	--version     $(TEST_VERSION) \
+	--dataset     "BB01-BB02-mismatched" \
+	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB02" \
+	--ped-file    "gs://cpg-seqr-test/datasets/BB02/BB02-mismatched.ped" \
+	--keep-scratch \
+	--reuse
+
+.PHONY: run_test_cram
+run_test_cram:
+	analysis-runner \
+	--dataset seqr \
+	--access-level test \
+	--output-dir  "gs://cpg-seqr-test-tmp/hail" \
+	--description "test seqr loader - cram" \
+	batch_seqr_loader/batch_workflow.py \
+	--namespace   test \
+	--version     $(TEST_VERSION) \
+	--dataset     "NA12878-cram" \
+	--cram-bucket "gs://cpg-seqr-test/datasets/NA12878-cram" \
 	--keep-scratch \
 	--reuse
 
@@ -73,12 +88,27 @@ run_zornitza-stark:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir  "gs://cpg-seqr-test/data/zornitza-stark-v0" \
+	--output-dir  "gs://cpg-seqr-test-tmp/hail" \
 	--description "test seqr loader - zornitza-stark" \
 	batch_seqr_loader/batch_workflow.py \
-	--namespace test \
+	--namespace   test \
+	--version     "v1-0" \
+	--dataset     "zornitza-stark" \
 	--bam-bucket  "gs://cpg-seqr-upload-zornitza-stark" \
-	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute.ped" \
-	--data-bucket "gs://cpg-seqr-test/data/zornitza-stark-v0" \
-	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)/work-zornitza-stark" \
+	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute-fixed.ped" \
+	--reuse
+
+.PHONY: run_zornitza-stark-kccg-gvcf
+run_zornitza-stark-kccg-gvcf:
+	analysis-runner \
+	--dataset seqr \
+	--access-level test \
+	--output-dir  "gs://cpg-seqr-test-tmp/hail" \
+	--description "seqr loader - zornitza-stark KCCG GVCFs" \
+	batch_seqr_loader/batch_workflow.py \
+	--namespace   test \
+	--version     "v1-0" \
+	--dataset     "zornitza-stark-kccg-gvcf" \
+	--gvcf-bucket "gs://cpg-seqr-upload-zornitza-stark" \
+	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute-fixed.ped" \
 	--reuse

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ run_test_mismatched:
 run_zornitza-stark:
 	analysis-runner \
 	--dataset seqr \
-	--access-level full \
+	--access-level test \
 	--output-dir  "gs://cpg-seqr-test/data/zornitza-stark-v0" \
 	--description "test seqr loader - zornitza-stark" \
 	batch_seqr_loader/batch_workflow.py \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ run_test:
 	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
 	--description "test seqr loader - test" \
 	batch_seqr_loader/batch_workflow.py \
+	--namespace test \
 	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
 	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01.ped" \
 	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
@@ -43,6 +44,7 @@ run_test_extend:
 	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
 	--description "test seqr loader - extend" \
 	batch_seqr_loader/batch_workflow.py \
+	--namespace test \
 	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB02" \
 	--ped-file    "gs://cpg-seqr-test/datasets/BB02/BB02.ped" \
 	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
@@ -58,6 +60,7 @@ run_test_mismatched:
 	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
 	--description "test seqr loader - mismatched" \
 	batch_seqr_loader/batch_workflow.py \
+	--namespace test \
 	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
 	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01-mismatched.ped" \
 	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
@@ -73,6 +76,7 @@ run_zornitza-stark:
 	--output-dir  "gs://cpg-seqr-test/data/zornitza-stark-v0" \
 	--description "test seqr loader - zornitza-stark" \
 	batch_seqr_loader/batch_workflow.py \
+	--namespace test \
 	--bam-bucket  "gs://cpg-seqr-upload-zornitza-stark" \
 	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute.ped" \
 	--data-bucket "gs://cpg-seqr-test/data/zornitza-stark-v0" \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1_2
+VERSION := v1-0
 
 .PHONY: package
 package:
@@ -25,14 +25,13 @@ run_test:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/hail" \
-	--description "test seqr loader - batch small1" \
+	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--description "test seqr loader - test" \
 	batch_seqr_loader/batch_workflow.py \
-	--gvcf-bucket "gs://cpg-seqr-test/gvcf/small1" \
-	--cram-bucket "gs://cpg-seqr-test/cram/small1" \
-	--ped-file    "gs://cpg-seqr-test/gvcf/small1/samples.ped" \
+	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
+	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01.ped" \
 	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
-	--work-bucket "gs://cpg-seqr-test-tmp/work/loader-$(VERSION)/work-small1-cram" \
+	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)" \
 	--keep-scratch \
 	--reuse
 
@@ -41,27 +40,41 @@ run_test_extend:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/hail" \
-	--description "test seqr loader - extend with batch small2" \
+	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--description "test seqr loader - extend" \
 	batch_seqr_loader/batch_workflow.py \
-	--gvcf-bucket  "gs://cpg-seqr-test/gvcf/small2" \
-	--ped-file     "gs://cpg-seqr-test/gvcf/small2/samples.ped" \
-	--data-bucket  "gs://cpg-seqr-test/data/test-$(VERSION)" \
-	--work-bucket  "gs://cpg-seqr-test-tmp/work/loader-$(VERSION)/work-small2" \
+	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB02" \
+	--ped-file    "gs://cpg-seqr-test/datasets/BB02/BB02.ped" \
+	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)-extend" \
 	--keep-scratch \
 	--reuse
 
-.PHONY: run_full_family
-run_full_family:
+.PHONY: run_test_mismatched
+run_test_mismatched:
 	analysis-runner \
 	--dataset seqr \
 	--access-level test \
-	--output-dir "gs://cpg-seqr-test-tmp/seqr_$(VERSION)/hail" \
-	--description "test seqr loader - families" \
+	--output-dir  "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--description "test seqr loader - mismatched" \
 	batch_seqr_loader/batch_workflow.py \
-	--gvcf-bucket "gs://cpg-seqr-test/gvcf/families" \
-	--ped-file    "gs://cpg-seqr-test/gvcf/families/samples.ped" \
-	--data-bucket "gs://cpg-seqr-test/data/families-$(VERSION)" \
-	--work-bucket "gs://cpg-seqr-test-tmp/work/loader-$(VERSION)/work-families" \
+	--gvcf-bucket "gs://cpg-seqr-test/datasets/BB01" \
+	--ped-file    "gs://cpg-seqr-test/datasets/BB01/BB01-mismatched.ped" \
+	--data-bucket "gs://cpg-seqr-test/data/test-$(VERSION)" \
+	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)-mismatched" \
 	--keep-scratch \
+	--reuse
+
+.PHONY: run_zornitza-stark
+run_zornitza-stark:
+	analysis-runner \
+	--dataset seqr \
+	--access-level full \
+	--output-dir  "gs://cpg-seqr-test/data/zornitza-stark-v0" \
+	--description "test seqr loader - zornitza-stark" \
+	batch_seqr_loader/batch_workflow.py \
+	--bam-bucket  "gs://cpg-seqr-upload-zornitza-stark" \
+	--ped-file    "gs://cpg-seqr-upload-zornitza-stark/cpg_acute.ped" \
+	--data-bucket "gs://cpg-seqr-test/data/zornitza-stark-v0" \
+	--work-bucket "gs://cpg-seqr-test-tmp/work/seqr-loader-$(VERSION)/work-zornitza-stark" \
 	--reuse

--- a/batch_seqr_loader/README.md
+++ b/batch_seqr_loader/README.md
@@ -2,34 +2,13 @@
 
 A loading pipeline, but formatted for Hail Batch, ultimately for automated ingestion of data into Seqr.
 
-The input is a set of GVCFs. It iteratively adds them into a [GenomicsDB](https://github.com/Intel-HLS/GenomicsDB/wiki) located on a bucket specified with `--genomicsdb-bucket`, jointly re-genotypes, converts into a Hail MatrixTable and annotates.
+The inputs are buckets with GVCFs, CRAMs or BAMs, as well as an optional PED file. It calls the variants if needed, and iteratively adds them into a [GenomicsDB](https://github.com/Intel-HLS/GenomicsDB/wiki), located on a bucket `gs://cpg-seqr-main/datasets`. Then it jointly re-genotypes all variants in a DB together, converts them into a Hail MatrixTable, and annotates.
 
-To run, use the analysis runner:
+Analysis runner must be used to run the workflow. For examples of commands, see the [Makefile](../Makefile) at the root of the repository. 
 
-```sh
-VERSION=v1.01
-analysis-runner \
-    --dataset seqr \
-    --access-level test \
-    --output-dir "gs://cpg-seqr-test-tmp/seqr_${VERSION}/hail" \
-    --description "test seqr loader - batch small1" \
-batch_seqr_loader/batch_workflow.py \
-    --gvcf-bucket gs://cpg-seqr-test/gvcf/small1 \
-    --ped-file gs://cpg-seqr-test/gvcf/small1/samples.ped \
-    --dataset seqr \
-    --work-bucket "gs://cpg-seqr-test/seqr_${VERSION}/work" \
-    --dest-mt-path "gs://cpg-seqr-test/seqr_${VERSION}/output/annotated.mt" \
-    --genomicsdb-bucket gs://cpg-seqr-test/seqr_${VERSION}/genomicsdb
-```
 
-This script will automatically start a Dataproc cluster where relevant.
+## Further work
 
-## Customisation
-
-This pipeline should be fairly configurable in a few ways:
-
-- Upload to ElasticSearch if elastic search credentials have been provided.
-
-Later additions:
-
-- Load pedigree data if provided ([using this process](https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1618551394039300))
+* Upload to ElasticSearch if elastic search credentials have been provided.
+* Load pedigree data if provided ([using this process](https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1618551394039300)).
+* Support re-aligning input CRAMs/BAMs/FASTQs if needed.

--- a/batch_seqr_loader/README.md
+++ b/batch_seqr_loader/README.md
@@ -4,7 +4,7 @@ A loading pipeline, but formatted for Hail Batch, ultimately for automated inges
 
 The inputs are buckets with GVCFs, CRAMs or BAMs, as well as an optional PED file. It calls the variants if needed, and iteratively adds them into a [GenomicsDB](https://github.com/Intel-HLS/GenomicsDB/wiki), located on a bucket `gs://cpg-seqr-main/datasets`. Then it jointly re-genotypes all variants in a DB together, converts them into a Hail MatrixTable, and annotates.
 
-Analysis runner must be used to run the workflow. For examples of commands, see the [Makefile](../Makefile) at the root of the repository. 
+The analysis-runner must be used to run the workflow. For examples of commands, see the [Makefile](../Makefile) at the root of the repository. 
 
 
 ## Further work

--- a/batch_seqr_loader/README.md
+++ b/batch_seqr_loader/README.md
@@ -9,6 +9,6 @@ Analysis runner must be used to run the workflow. For examples of commands, see 
 
 ## Further work
 
-* Upload to ElasticSearch if elastic search credentials have been provided.
+* Upload to Elasticsearch if corresponding credentials have been provided.
 * Load pedigree data if provided ([using this process](https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1618551394039300)).
 * Support re-aligning input CRAMs/BAMs/FASTQs if needed.

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -121,6 +121,12 @@ logger.setLevel(logging.INFO)
     is_flag=True,
     help='Create checkpoints for intermediate Hail data',
 )
+@click.option(
+    '--namespace',
+    'namespace',
+    type=click.Choice(['main', 'test']),
+    help='Bucket namespace: test or main',
+)
 @click.option('--vep-block-size', 'vep_block_size')
 def main(
     gvcf_buckets: List[str],
@@ -136,6 +142,7 @@ def main(
     remap_path: str,
     subset_path: str,
     make_checkpoints: bool,
+    namespace: Optional[str] = None,
     vep_block_size: Optional[int] = None,  # pylint: disable=unused-argument
 ):
     """
@@ -181,7 +188,7 @@ def main(
         + '.dict',
     )
 
-    ped_check_j = _pedigree_checks(
+    ped_check_j, ped_fpath = _pedigree_checks(
         b=b,
         samples_df=samples_df,
         reference=reference,
@@ -190,6 +197,7 @@ def main(
         work_bucket=work_bucket,
         overwrite=overwrite,
         fingerprints_bucket=join(data_bucket, 'fingerprints'),
+        namespace=namespace,
     )
 
     # realign_bam_jobs = _make_realign_bam_jobs(
@@ -273,12 +281,15 @@ def _pedigree_checks(
     work_bucket: str,  # pylint: disable=unused-argument
     overwrite: bool,  # pylint: disable=unused-argument
     fingerprints_bucket: str,
+    namespace: Optional[str] = None,
     depends_on: Optional[List[Job]] = None,
-) -> Job:
+) -> Tuple[Job, str]:
     """
-    Add somalier and peddy based jobs that infer relatedness
-    and sex, and compare that to the provided ped file, and fail
-    if anything don't match
+    Add somalier and peddy based jobs that infer relatedness and sex, compare that
+    to the provided PED file, and attempt to recover it. If unable to recover, cancel
+    the further workflow jobs.
+
+    Returns a job, and a bucket path to a fixed PED file if able to recover.
     """
 
     extract_jobs = []
@@ -346,14 +357,24 @@ def _pedigree_checks(
       """
     )
 
+    # Copy somalier outputs to buckets
     sample_hash = hash_sample_names(samples_df['s'])
+
+    somalier_html_url = None
+    if namespace:
+        web_bucket = f'gs://cpg-seqr-{namespace}-web'
+        rel_path = join('loader', sample_hash[:10], 'somalier.html')
+        somalier_path = join(web_bucket, rel_path)
+        somalier_html_url = (
+            f'https://{namespace}-web.populationgenomics.org.au/seqr/{rel_path}'
+        )
+        b.write_output(relate_j.output_html, somalier_path)
     prefix = join(fingerprints_bucket, sample_hash, 'somalier')
-    somalier_html_path = f'{prefix}.html'
     somalier_samples_path = f'{prefix}.samples.tsv'
     somalier_pairs_path = f'{prefix}.pairs.tsv'
-    b.write_output(relate_j.output_html, somalier_html_path)
     b.write_output(relate_j.output_samples, somalier_samples_path)
     b.write_output(relate_j.output_pairs, somalier_pairs_path)
+
     check_j = b.new_job(f'Check relatedness and sex')
     check_j.image(PEDDY_CONTAINER)
     check_j.memory(f'8G')
@@ -368,12 +389,12 @@ EOT
 python check_pedigree.py \\
 --somalier-samples {relate_j.output_samples} \\
 --somalier-pairs {relate_j.output_pairs} \\
---somalier-html {somalier_html_path}
+{('--somalier-html ' + somalier_html_url) if somalier_html_url else ''}
     """
     )
 
     check_j.depends_on(relate_j)
-    return check_j
+    return check_j, somalier_samples_path
 
 
 def _make_genotype_jobs(

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -36,7 +36,7 @@ SOMALIER_CONTAINER = 'brentp/somalier:latest'
 PEDDY_CONTAINER = 'quay.io/biocontainers/peddy:0.4.8--pyh5e36f6f_0'
 
 # Fixed scatter count, because we are storing a genomics DB per each interval
-NUMBER_OF_HAPLOTYPE_CALLER_INTERVALS = 10
+NUMBER_OF_HAPLOTYPE_CALLER_INTERVALS = 50
 NUMBER_OF_GENOMICS_DB_INTERVALS = 10
 
 REF_BUCKET = 'gs://cpg-reference/hg38/v0'
@@ -628,17 +628,6 @@ def _add_haplotype_caller_job(
     """
     Run HaplotypeCaller on an input BAM or CRAM, and output GVCF
     """
-
-    # We need disk to localize the sharded input and output due to the scatter for
-    # HaplotypeCaller. If we take the number we are scattering by and reduce by 20,
-    # we will have enough disk space to account for the fact that the data is quite
-    # uneven across the shards.
-    # scatter_divisor = max((number_of_intervals - 20), 1)
-    # input_and_output_size = 40
-    # reference_data_size = 20
-    # disk_size = math.ceil(input_and_output_size / scatter_divisor) + reference_data_size
-    disk_size = 32
-
     job_name = 'HaplotypeCaller'
     if interval_idx is not None:
         job_name += f', {sample_name} {interval_idx}/{number_of_intervals}'
@@ -648,7 +637,7 @@ def _add_haplotype_caller_job(
     j.cpu(2)
     java_mem = 7
     j.memory('standard')  # ~ 4 Gi/core ~ 8
-    j.storage(f'{disk_size}G')
+    j.storage('16G')
     j.declare_resource_group(
         output_gvcf={
             'g.vcf.gz': '{root}-' + sample_name + '.g.vcf.gz',

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -623,8 +623,8 @@ def _add_haplotype_caller_job(
     j = b.new_job(job_name)
     j.image(GATK_CONTAINER)
     j.cpu(2)
-    j.memory('highmem')  # ~ 7 Gi/core ~ 14
-    java_mem = 13
+    java_mem = 7
+    j.memory('standard')  # ~ 4 Gi/core ~ 8
     j.storage(f'{disk_size}G')
     j.declare_resource_group(
         output_gvcf={

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -657,7 +657,7 @@ def _add_haplotype_caller_job(
       -GQB 10 -GQB 20 -GQB 30 -GQB 40 -GQB 50 -GQB 60 -GQB 70 -GQB 80 -GQB 90 \
       -ERC GVCF \
 
-    df -h; pwd; du -sh *
+    df -h; pwd
     """
     )
     return j
@@ -697,7 +697,7 @@ def _add_merge_gvcfs_job(
     java -Xms{java_mem}g -jar /usr/picard/picard.jar \
       MergeVcfs {input_cmd} OUTPUT={j.output_gvcf['g.vcf.gz']}
 
-    df -h; pwd; du -sh *
+    df -h; pwd
       """
     )
     if output_gvcf_path:
@@ -828,11 +828,11 @@ def _add_import_gvcfs_job(
       --merge-input-intervals \
       --consolidate
 
-    df -h; pwd; du -sh *
+    df -h; pwd
 
     tar -cf {j.output['tar']} workspace
 
-    df -h; pwd; du -sh *
+    df -h; pwd
     """
     )
     b.write_output(j.output, genomicsdb_gcs_path.replace('.tar', ''))
@@ -882,7 +882,7 @@ def _add_gatk_genotype_gvcf_job(
 
     tar -xf {genomicsdb}
 
-    df -h; pwd; du -sh *
+    df -h; pwd
 
     gatk --java-options -Xms{java_mem}g \\
       GenotypeGVCFs \\
@@ -894,7 +894,7 @@ def _add_gatk_genotype_gvcf_job(
       -L {interval} \\
       --merge-input-intervals
 
-    df -h; pwd; du -sh *
+    df -h; pwd
     """
     )
     if output_vcf_path:
@@ -947,7 +947,7 @@ def _add_final_gather_vcf_step(
 
     tabix {j.output_vcf['vcf.gz']}
     
-    df -h; pwd; du -sh *
+    df -h; pwd
     """
     )
     if output_vcf_path:

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -80,7 +80,7 @@ logger.setLevel(logging.INFO)
     help='Bucket path with input BAM or CRAM files that need re-alignment',
 )
 @click.option(
-    '--dataset',
+    '--seqr-dataset',
     'dataset_name',
     required=True,
     help='Name of the dataset. If a genomics DB already exists for this dataset, '

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -337,11 +337,11 @@ def _pedigree_checks(
         else:
             j = b.new_job(f'Somalier extract, {sn}')
             j.image(SOMALIER_CONTAINER)
-            j.memory(f'8G')
+            j.cpu(1)
             if input_path.endswith('.bam'):
-                j.storage(f'120G')
+                j.storage(f'200G')
             elif input_path.endswith('.cram'):
-                j.storage(f'30G')
+                j.storage(f'50G')
             else:
                 j.storage(f'10G')
             if depends_on:
@@ -369,8 +369,8 @@ def _pedigree_checks(
 
     relate_j = b.new_job(f'Somalier relate')
     relate_j.image(SOMALIER_CONTAINER)
-    relate_j.memory(f'8G')
-    relate_j.storage(f'10G')
+    relate_j.cpu(1)
+    relate_j.storage('10G')
     relate_j.depends_on(*extract_jobs)
     fp_files = [b.read_input(fp) for sn, fp in fp_file_by_sample.items()]
     relate_j.command(

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -584,7 +584,7 @@ def _add_split_intervals_job(
     """
     j = b.new_job(f'Make {scatter_count} intervals')
     j.image(GATK_CONTAINER)
-    java_mem = 3.5
+    java_mem = 3
     j.memory('standard')  # ~ 4G/core ~ 4G
     j.storage('16G')
     j.declare_resource_group(

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -293,7 +293,12 @@ def _pedigree_checks(
             j = b.new_job(f'Somalier extract, {sn}')
             j.image(SOMALIER_CONTAINER)
             j.memory(f'8G')
-            j.storage(f'10G')
+            if input_path.endswith('.bam'):
+                j.storage(f'120G')
+            if input_path.endswith('.cram'):
+                j.storage(f'30G')
+            else:
+                j.storage(f'10G')
             if depends_on:
                 j.depends_on(*depends_on)
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -295,7 +295,7 @@ def _pedigree_checks(
             j.memory(f'8G')
             if input_path.endswith('.bam'):
                 j.storage(f'120G')
-            if input_path.endswith('.cram'):
+            elif input_path.endswith('.cram'):
                 j.storage(f'30G')
             else:
                 j.storage(f'10G')

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -83,7 +83,7 @@ logger.setLevel(logging.INFO)
     '--seqr-dataset',
     'dataset_name',
     required=True,
-    help='Name of the dataset. If a genomics DB already exists for this dataset, '
+    help='Name of the seqr callset. If a genomics DB already exists for this dataset, '
     'it will be extended with the new samples',
 )
 @click.option('--version', 'dataset_version', type=str, required=True)

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -866,8 +866,8 @@ def _add_gatk_genotype_gvcf_job(
     j.cpu(2)
     java_mem = 7
     j.memory('standard')  # ~ 4G/core ~ 8G
-    # 1G + 1G per sample divided by the number of intervals
-    j.storage(f'{1 + number_of_samples * 1 // number_of_intervals}G')
+    # 12G (dbsnp) + 4G (fasta+fai+dict) + 1G per sample divided by the number of intervals
+    j.storage(f'{12 + 4 + number_of_samples * 1 // number_of_intervals}G')
     j.declare_resource_group(
         output_vcf={
             'vcf.gz': '{root}.vcf.gz',

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -606,6 +606,7 @@ def _add_split_intervals_job(
       -mode INTERVAL_SUBDIVISION
       """
     )
+    # Could save intervals to a bucket here to avoid rerunning the job
     return j
 
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -783,8 +783,8 @@ def _add_import_gvcfs_job(
     j = b.new_job(job_name)
     j.image(GATK_CONTAINER)
     j.cpu(16)
-    java_mem = 15
-    j.memory('lowmem')  # ~ 1G/core ~ 16G
+    java_mem = 14
+    j.memory('lowmem')  # ~ 1G/core ~ 14.4G
     # 1G + 1G per sample divided by the number of intervals
     j.storage(f'{1 + len(samples_will_be_in_db) * 1 // number_of_intervals}G')
     if depends_on:

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -335,8 +335,8 @@ def _pedigree_checks(
         else:
             j = b.new_job(f'Somalier extract, {sn}')
             j.image(SOMALIER_CONTAINER)
-            j.cpu(1)
-            j.memory('standard')  # ~ 4G/core ~ 4G
+            j.cpu(2)
+            j.memory('highmem')  # ~ 4G/core ~ 8G
             if input_path.endswith('.bam'):
                 j.storage(f'200G')
             elif input_path.endswith('.cram'):

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -196,11 +196,12 @@ def main(
 
     local_tmp_dir = tempfile.mkdtemp()
 
-    samples_df = find_inputs(
+    samples_df, ped_fpath = find_inputs(
         gvcf_buckets,
         bam_buckets,
         bam_to_realign_buckets,
         local_tmp_dir=local_tmp_dir,
+        work_bucket=work_bucket,
         ped_fpath=ped_fpath,
     )
 

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -679,7 +679,7 @@ def _add_merge_gvcfs_job(
     j.cpu(2)
     java_mem = 7
     j.memory('standard')  # ~ 4G/core ~ 7.5G
-    j.storage(f'{len(gvcfs) * 1 + 1}G')
+    j.storage(f'{len(gvcfs) * 1.5 + 2}G')
     j.declare_resource_group(
         output_gvcf={
             'g.vcf.gz': '{root}-' + sample_name + '.g.vcf.gz',

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -659,7 +659,7 @@ def _add_haplotype_caller_job(
 
     j.command(
         f"""set -e
-    (while true; do df -h; pwd; du -sh *; free -m; sleep 300; done) &
+    (while true; do df -h; pwd; free -m; sleep 300; done) &
 
     gatk --java-options "-Xms{java_mem}g -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10" \
       HaplotypeCaller \
@@ -706,7 +706,7 @@ def _add_merge_gvcfs_job(
     j.command(
         f"""set -e
 
-    (while true; do df -h; pwd; du -sh *; free -m; sleep 300; done) &
+    (while true; do df -h; pwd; free -m; sleep 300; done) &
 
     java -Xms{java_mem}g -jar /usr/picard/picard.jar \
       MergeVcfs {input_cmd} OUTPUT={j.output_gvcf['g.vcf.gz']}
@@ -829,7 +829,7 @@ def _add_import_gvcfs_job(
     
     {untar_genomicsdb_cmd}
 
-    (while true; do df -h; pwd; du -sh *; free -m; sleep 300; done) &
+    (while true; do df -h; pwd; free -m; sleep 300; done) &
 
     gatk --java-options -Xms{java_mem}g \
       GenomicsDBImport \
@@ -889,7 +889,7 @@ def _add_gatk_genotype_gvcf_job(
     j.command(
         f"""set -e
         
-    (while true; do df -h; pwd; du -sh *; free -m; sleep 300; done) &
+    (while true; do df -h; pwd; free -m; sleep 300; done) &
 
     tar -xf {genomicsdb}
 
@@ -943,7 +943,7 @@ def _add_final_gather_vcf_step(
     j.command(
         f"""set -euo pipefail
 
-    (while true; do df -h; pwd; du -sh *; free -m; sleep 300; done) &
+    (while true; do df -h; pwd; free -m; sleep 300; done) &
 
     # --ignore-safety-checks makes a big performance difference so we include it in 
     # our invocation. This argument disables expensive checks that the file headers 

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -2,8 +2,9 @@
 
 """
 This script parses `somalier relate` (https://github.com/brentp/somalier) outputs,
-and returns a non-zero code if either sex or pedigree is mismatching
+and returns a non-zero code if either sex or pedigree mismatches the data in a provided PED file.
 """
+
 import contextlib
 import logging
 import subprocess

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -102,7 +102,7 @@ def main(
         }
         if inferred_rel not in provided_to_inferred[provided_rel]:
             mismatching_pairs.append(
-                f'{s1}-{s2}, '
+                f'"{s1}" and "{s2}", '
                 f'provided relationship: "{provided_rel}", inferred: "{inferred_rel}"'
             )
     if mismatching_pairs:

--- a/batch_seqr_loader/check_pedigree.py
+++ b/batch_seqr_loader/check_pedigree.py
@@ -148,9 +148,6 @@ def infer_relationship(coeff: float, ibs0: float, ibs2: float) -> str:
         result = 'unrelated'
     elif 0.1 <= coeff < 0.38:
         result = 'below_first_degree'
-        # Distinguish between uncle/grandparent and double-first cousins, setting the latter to unrelated
-        # Remove any relationship below uncle/grandparent from the second degree relatives category
-
     elif 0.38 <= coeff <= 0.62:
         if ibs0 / ibs2 < 0.005:
             result = 'parent-child'

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -168,7 +168,7 @@ def _df_based_on_ped_file(
     """
     local_sample_list_fpath = join(local_tmp_dir, basename(ped_fpath))
     subprocess.run(
-        f'gsutil cat {ped_fpath} | grep -v ^Family.ID > {local_sample_list_fpath}',
+        f'gsutil cat {ped_fpath} | grep -v ^Family.ID | cut -f1-6 > {local_sample_list_fpath}',
         check=False,
         shell=True,
     )

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -186,12 +186,12 @@ def _df_based_on_ped_file(
             matching_sn = [sn for sn in ped_snames if sn == input_sname]
             if len(matching_sn) > 1:
                 logging.warning(
-                    f'Multiple samples found for the input {input_sname}:'
+                    f'Multiple PED records found for the input {input_sname}:'
                     f'{matching_sn}'
                 )
                 mismatches_with_ped_found = True
             elif len(matching_sn) == 0:
-                logging.warning(f'No samples found for the input {input_sname}')
+                logging.warning(f'No PED records found for the input {input_sname}')
                 mismatches_with_ped_found = True
             else:
                 df.loc[matching_sn[0], 'type'] = input_type

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -59,7 +59,7 @@ def find_inputs(
 
     else:
         # PED file not provided, so creating DataFrame purely from the found input files
-        data: Dict[str, List] = dict(s=[], file=[], type=[])
+        data: Dict[str, List] = dict(s=[], file=[], index=[], type=[])
         for input_type in found_files_by_type:
             for fp, index in zip(
                 found_files_by_type[input_type], found_indices_by_type[input_type]

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -91,8 +91,8 @@ def find_inputs(
 
         df = pd.DataFrame(data=data).set_index('s', drop=False)
         ped_fpath = join(work_bucket, 'bare.ped')
-        df[['fam_id', 's', 'father_id', 'mother_id', 'sex', 'phenotype']].write(
-            ped_fpath
+        df[['fam_id', 's', 'father_id', 'mother_id', 'sex', 'phenotype']].to_csv(
+            ped_fpath, sep='\t', header=False, index=False
         )
 
     return df, ped_fpath

--- a/batch_seqr_loader/test/BB01-mismatched.ped
+++ b/batch_seqr_loader/test/BB01-mismatched.ped
@@ -1,0 +1,4 @@
+Family.ID	Individual.ID	Paternal.ID	Maternal.ID	Gender	Phenotype	Population	Other.info	Relationships.from.Pemberton.et.al.AJHG.2010	Broad.IBD.Analysis	sequence_read	alignment	high_coverage_alignment	exome_alignment	gvcf	gatksv_cram
+BB01	HG01879	0	0	2	0	ACB	grandmother	0		True	True	True	True	True	
+BB01	HG01880	0	0	2	0	ACB	mother	0		True	True	False	True	True	gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG01880/analysis/HG01880.final.cram
+BB01	HG01881	HG01879	HG01880	2	0	ACB	child	0		False	False	False	False	True	

--- a/batch_seqr_loader/test/BB01.ped
+++ b/batch_seqr_loader/test/BB01.ped
@@ -1,0 +1,4 @@
+Family.ID	Individual.ID	Paternal.ID	Maternal.ID	Gender	Phenotype	Population	Other.info	Relationships.from.Pemberton.et.al.AJHG.2010	Broad.IBD.Analysis	sequence_read	alignment	high_coverage_alignment	exome_alignment	gvcf	gatksv_cram
+BB01	HG01879	0	0	1	0	ACB	father	0		True	True	True	True	True	
+BB01	HG01880	0	0	2	0	ACB	mother	0		True	True	False	True	True	gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG01880/analysis/HG01880.final.cram
+BB01	HG01881	HG01879	HG01880	2	0	ACB	child	0		False	False	False	False	True	

--- a/batch_seqr_loader/test/BB02.ped
+++ b/batch_seqr_loader/test/BB02.ped
@@ -1,0 +1,4 @@
+Family.ID	Individual.ID	Paternal.ID	Maternal.ID	Gender	Phenotype	Population	Other.info	Relationships.from.Pemberton.et.al.AJHG.2010	Broad.IBD.Analysis	sequence_read	alignment	high_coverage_alignment	exome_alignment	gvcf	gatksv_cram
+BB02	HG01882	0	0	1	0	ACB	father	0		True	True	False	True	True	
+BB02	HG01883	0	0	2	0	ACB	mother	0		True	True	False	True	True	
+BB02	HG01888	HG01882	HG01883	1	0	ACB	child	0		False	False	False	False	True	

--- a/batch_seqr_loader/test/README.md
+++ b/batch_seqr_loader/test/README.md
@@ -1,0 +1,43 @@
+# Generate test data
+
+* Clone the `fewgenomes` repository, and generate the test dataset for 2 families:
+
+```bash
+git clone https://github.com/populationgenomics/fewgenomes
+pushd fewgenomes
+snakemake -s prep_warp_inputs.smk -j2 -p --config families=2 input_type=gvcf dataset_name=seqr-gvcf
+popd
+```
+
+* Copy the data from `fewgenomes` buckets to the `seqr` buckets
+
+```bash
+PED=fewgenomes/datasets/seqr-gvcf/samples.ped
+for fam in $(cut -f1 $PED | tail -n+2 | sort -u); do
+    echo $fam
+    # Split the 2-families PED file into 2 separate PED files to test extending genomicsdbs
+    head -n1 $PED > $fam.ped
+    grep $fam $PED >> $fam.ped
+    gsutil cp $fam.ped gs://cpg-seqr-test/datasets/$fam/
+    # Copy GVCFs
+    for sam in $(grep $fam $PED | cut -f2); do 
+        echo $sam
+        gsutil cp gs://cpg-fewgenomes-main/gvcf/batch0/$sam.g.vcf.gz gs://cpg-seqr-test/datasets/$fam/
+        gsutil cp gs://cpg-fewgenomes-main/gvcf/batch0/$sam.g.vcf.gz.tbi gs://cpg-seqr-test/datasets/$fam/
+    done
+done
+```
+
+* Create a PED file version with mismatched sex and relationships:
+
+```bash
+# Make a mismatched dataset to test pedigree checks:
+PED=$(ls *.ped | head -n1)
+FAM=${PED//.ped/}
+PED_MISMATCHED=${PED//.ped/-mismatched.ped}
+cat $PED | head -n1 > $PED_MISMATCHED
+cat $PED | tail -n+2 | grep father | sed $'s/\t1\t/\t2\t/g' | sed 's/father/grandmother/' >> $PED_MISMATCHED
+cat $PED | tail -n+2 | grep father | tail -n+2 >> $PED_MISMATCHED
+cat $PED | tail -n+2 | grep -v father >> $PED_MISMATCHED
+gsutil cp $PED_MISMATCHED gs://cpg-seqr-test/datasets/$FAM/
+```


### PR DESCRIPTION
Multiple updates to the batch workflow. Hopefully the summary below is helpful.

* Instead of providing buckets paths explicitly as inputs, specify the namespace (`main`/`test`), the dataset name, and the run version, and use buckets starting from `gs://cpg-seqr-test/`/`gs://cpg-seqr-main/`. Helps to keep buckets cleaner.
* Optimise memory/cpu/storage resources.
* Add storage and memory monitoring that would help to optimise the resources further.
* Use 50 intervals for HaplotypeCaller and 10 for joint genotyping (seem to be optimal).
* Avoid localizing the dbSNP file (saves 11G of storage for joint genotyping jobs).
* Add option `--skip-ped-checks` which will be useful if we are okay with failed PED checks.
* PED checks:
	* Don't fail if a sex was missing, but successfully recovered. Fail only if it was specified but turns out to be mismatching. 
	* Output a "recovered" PED file with inferred sex where the original PED file had missing records.
	* Print more debug info in PED check (somalier outputs)
	* Upload somalier HTML file to a web bucket.
	* Treat relatedness coefficient <0.1 as unrelated (i.e. we don't care about further than the 2nd degree relatedness for now).
* Add test PED files (good and mismatching), and README on how the test data was generated.

Test run:
https://batch.hail.populationgenomics.org.au/batches/3067

Zornitza Stark samples (interrupted the pipeline at the seqr_load.py stage to restart later with Michael's 🔥 optimisations):
https://batch.hail.populationgenomics.org.au/batches/3033
