### PR TITLE
Fix for `samples.meta`. Remove version from CRAM/GVCF output. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ run_seqr_loader_test:
 	batch_seqr_loader/batch_workflow.py \
 	--namespace test \
 	--analysis-project seqr-test \
+	--input-project acute-care \
 	--input-project perth-neuro \
 	--output-version $(TEST_VERSION) \
 	--reuse \

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -311,7 +311,7 @@ def _add_jobs(
 
         for s in samples:
             logger.info(f'Project {proj}. Processing sample {s["id"]}')
-            expected_cram_path = f'{proj_bucket}/cram/{output_version}/{s["id"]}.cram'
+            expected_cram_path = f'{proj_bucket}/cram/{s["id"]}.cram'
             skip_cram_stage = start_from_stage is not None and start_from_stage not in [
                 'cram'
             ]
@@ -352,9 +352,7 @@ def _add_jobs(
                 )
                 continue
 
-            expected_gvcf_path = (
-                f'{proj_bucket}/gvcf/{output_version}/{s["id"]}.g.vcf.gz'
-            )
+            expected_gvcf_path = f'{proj_bucket}/gvcf/{s["id"]}.g.vcf.gz'
             skip_gvcf_stage = start_from_stage is not None and start_from_stage not in [
                 'cram',
                 'gvcf',

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -264,7 +264,7 @@ def _add_jobs(
 
     samples_by_project: Dict[str, List[Dict]] = dict()
     for proj in input_projects:
-        logger.info(f'Processing project {proj}')
+        logger.info(f'Finding samples for project {proj}')
         input_proj = proj
         if output_suffix != 'main':
             input_proj += '-test'
@@ -293,6 +293,7 @@ def _add_jobs(
     good_samples: List[Dict] = []
     hc_intervals_j = None
     for proj, samples in samples_by_project.items():
+        logger.info(f'Processing project {proj}')
         proj_bucket = f'gs://cpg-{proj}-{output_suffix}'
         sample_ids = [s['id'] for s in samples]
 


### PR DESCRIPTION
* `acute-care` was loaded into the SM DB before we switched to storing fastq data in `sequence.meta` instead of `sample.meta`, so need a small adjustment in the pipeline for that. We already have all CRAMs for `acute-care` so don't need to realign anything, so that just to make the `sm_verify_reads_data` check happy.
* No need for the version run in the CRAMs and GVCFs location (they will be stored in `gs://cpg-acute-care-main/gvcf` and `gs://cpg-acute-care-main/cram`).

Test: https://batch.hail.populationgenomics.org.au/batches/5625