### PR TITLE
Loading pipeline: standard BWA, option for HC shards, options for faster testings, fixes

### DIFF
--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -770,9 +770,9 @@ set -ex
 {pull_inputs_cmd}
 
 bwa mem -K 100000000 {'-p' if use_bazam else ''} -t{bwa_cpu} -Y \\
-        -R '{rg_line}' {reference.base} {r1_param} {r2_param} | \\
-    samtools sort -T $(dirname {j.sorted_bam})/samtools-sort-tmp \\
-        -Obam -o {j.sorted_bam}
+    -R '{rg_line}' {reference.base} {r1_param} {r2_param} | \\
+samtools sort -T $(dirname {j.sorted_bam})/samtools-sort-tmp \\
+    -Obam -o {j.sorted_bam}
 
 df -h; pwd; du -sh $(dirname {j.sorted_bam})
     """

--- a/batch_seqr_loader/batch_workflow.py
+++ b/batch_seqr_loader/batch_workflow.py
@@ -154,8 +154,6 @@ def main(
     use_gnarly: bool,
     use_as_vqsr: bool,
 ):  # pylint: disable=missing-function-docstring
-    billing_project = os.getenv('HAIL_BILLING_PROJECT') or 'seqr'
-
     if output_namespace in ['test', 'tmp']:
         tmp_bucket_suffix = 'test-tmp'
     else:
@@ -187,6 +185,7 @@ def main(
     if not hail_bucket or keep_scratch:
         # Scratch files are large, so we want to use the temporary bucket to put them in
         hail_bucket = f'{tmp_bucket}/hail'
+    billing_project = os.getenv('HAIL_BILLING_PROJECT') or 'seqr'
     logger.info(
         f'Starting hail Batch with the project {billing_project}, '
         f'bucket {hail_bucket}'
@@ -194,6 +193,7 @@ def main(
     backend = hb.ServiceBackend(
         billing_project=billing_project,
         bucket=hail_bucket.replace('gs://', ''),
+        token=os.getenv('HAIL_TOKEN'),
     )
     b = hb.Batch(
         f'Seqr loading. '
@@ -272,7 +272,7 @@ def _add_jobs(  # pylint: disable=too-many-statements
                 'project_ids': [input_proj],
                 'active': True,
             }
-        )[:2]
+        )
         samples_by_project[proj] = []
         for s in samples:
             if skip_samples and s['id'] in skip_samples:
@@ -330,10 +330,10 @@ def _add_jobs(  # pylint: disable=too-many-statements
                 cram_job = None
             else:
                 seq_info = seq_info_by_s_id[s['id']]
-                logger.info('Checking sequence.meta')
+                logger.info('Checking sequence.meta:')
                 alignment_input = sm_verify_reads_data(seq_info['meta'])
                 if not alignment_input:
-                    logger.info('Checking sample.meta')
+                    logger.info('Checking sample.meta:')
                     alignment_input = sm_verify_reads_data(s['meta'])
                 if alignment_input:
                     cram_job = _make_realign_jobs(
@@ -674,12 +674,6 @@ def _make_realign_jobs(
     total_cpu = 32
     j.cpu(total_cpu)
     j.memory('standard')
-    j.declare_resource_group(
-        output_cram={
-            'cram': '{root}.cram',
-            'cram.crai': '{root}.cram.crai',
-        }
-    )
 
     pull_inputs_cmd = ''
 
@@ -687,7 +681,6 @@ def _make_realign_jobs(
         use_bazam = True
         bazam_cpu = 10
         bwa_cpu = 32
-        bamsormadup_cpu = 10
         assert alignment_input.index_path
         assert not alignment_input.fqs1 and not alignment_input.fqs2
         j.storage(
@@ -720,7 +713,6 @@ def _make_realign_jobs(
         assert alignment_input.fqs1 and alignment_input.fqs2
         use_bazam = False
         bwa_cpu = 32
-        bamsormadup_cpu = 10
         j.storage('600G')
 
         files1 = [b.read_input(f1) for f1 in alignment_input.fqs1]
@@ -741,25 +733,50 @@ def _make_realign_jobs(
 set -o pipefail
 set -ex
 
-(while true; do df -h; pwd; du -sh $(dirname {j.output_cram.cram}); sleep 600; done) &
+(while true; do df -h; pwd; du -sh $(dirname {j.sorted_bam}); sleep 600; done) &
 
 {pull_inputs_cmd}
 
 bwa-mem2 mem -K 100000000 {'-p' if use_bazam else ''} -t{bwa_cpu} -Y \\
-    -R '{rg_line}' {reference.base} {r1_param} {r2_param} | \\
-bamsormadup inputformat=sam threads={bamsormadup_cpu} SO=coordinate \\
-    M={j.duplicate_metrics} outputformat=sam \\
-    tmpfile=$(dirname {j.output_cram.cram})/bamsormadup-tmp | \\
-samtools view -T {reference.base} -O cram -o {j.output_cram.cram}
+        -R '{rg_line}' {reference.base} {r1_param} {r2_param} | \\
+    samtools sort -T $(dirname {j.sorted_bam})/samtools-sort-tmp \\
+        -Obam -o {j.sorted_bam}
 
-samtools index -@{total_cpu} {j.output_cram.cram} {j.output_cram['cram.crai']}
-
-df -h; pwd; du -sh $(dirname {j.output_cram.cram})
+df -h; pwd; du -sh $(dirname {j.sorted_bam})
     """
     j.command(command)
-    b.write_output(j.output_cram, splitext(output_path)[0])
+
+    md_j = b.new_job('MarkDuplicates')
+    md_j.image(utils.ALIGNMENT_IMAGE)
+    md_j.declare_resource_group(
+        output_cram={
+            'cram': '{root}.cram',
+            'cram.crai': '{root}.cram.crai',
+        }
+    )
+    command = f"""
+set -o pipefail
+set -ex
+
+(while true; do df -h; pwd; du -sh $(dirname {md_j.output_cram.cram}); sleep 600; done) &
+
+picard MarkDuplicates \\
+    I={j.sorted_bam} O=/dev/stdout M={md_j.duplicate_metrics} \\
+    TMP_DIR=$(dirname {md_j.output_cram.cram})/picard-tmp \\
+    ASSUME_SORT_ORDER=coordinate | \\
+samtools view -@30 -T {reference.base} -O cram -o {md_j.output_cram.cram}
+
+samtools index -@2 {md_j.output_cram.cram} {md_j.output_cram['cram.crai']}
+
+df -h; pwd; du -sh $(dirname {md_j.output_cram.cram})
+    """
+    md_j.command(command)
+    md_j.cpu(2)
+    md_j.memory('standard')
+    md_j.storage('150G')
+    b.write_output(md_j.output_cram, splitext(output_path)[0])
     b.write_output(
-        j.duplicate_metrics,
+        md_j.duplicate_metrics,
         join(
             dirname(output_path),
             'duplicate-metrics',
@@ -804,12 +821,12 @@ df -h; pwd; du -sh $(dirname {j.output_cram.cram})
     else:
         sm_completed_j = None
         if depends_on:
-            j.depends_on(*depends_on)
+            md_j.depends_on(*depends_on)
 
     if sm_completed_j:
         return sm_completed_j
     else:
-        return j
+        return md_j
 
 
 def _make_produce_gvcf_jobs(

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -292,17 +292,18 @@ class AlignmentInput:
 
 
 def sm_verify_reads_data(  # pylint: disable=too-many-return-statements
-    reads_data: Optional[List],
-    reads_type: Optional[str],
+    meta: Dict,
 ) -> Optional[AlignmentInput]:
     """
     Verify the meta.reads object in a sample db entry
     """
+    reads_data = meta.get('reads')
+    reads_type = meta.get('reads_type')
     if not reads_data:
-        logger.error(f'ERROR: no "meta/reads" field')
+        logger.error(f'No "meta/reads" field in meta')
         return None
     if not reads_type:
-        logger.error(f'ERROR: no "meta/reads_type" field')
+        logger.error(f'No "meta/reads_type" field in meta')
         return None
     supported_types = ('fastq', 'bam', 'cram')
     if reads_type not in supported_types:

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -291,8 +291,9 @@ class AlignmentInput:
     fqs2: Optional[List[str]] = None
 
 
-def sm_verify_reads_data(  # pylint: disable=too-many-return-statements
+def sm_get_reads_data(  # pylint: disable=too-many-return-statements
     meta: Dict,
+    check_existence: bool = True,
 ) -> Optional[AlignmentInput]:
     """
     Verify the meta.reads object in a sample db entry
@@ -322,7 +323,7 @@ def sm_verify_reads_data(  # pylint: disable=too-many-return-statements
                 f'got: {bam_path}'
             )
             return None
-        if not file_exists(bam_path):
+        if check_existence and not file_exists(bam_path):
             logger.error(f'ERROR: index file doesn\'t exist: {bam_path}')
             return None
 
@@ -344,7 +345,7 @@ def sm_verify_reads_data(  # pylint: disable=too-many-return-statements
                 f'ERROR: expected the index file to have an extention '
                 f'.crai or .bai, got: {index_path}'
             )
-        if not file_exists(index_path):
+        if check_existence and not file_exists(index_path):
             logger.error(f'ERROR: index file doesn\'t exist: {index_path}')
             return None
 
@@ -355,12 +356,12 @@ def sm_verify_reads_data(  # pylint: disable=too-many-return-statements
         fqs2 = []
         for lane_data in reads_data:
             assert len(lane_data) == 2, lane_data
-            if not file_exists(lane_data[0]['location']):
+            if check_existence and not file_exists(lane_data[0]['location']):
                 logger.error(
                     f'ERROR: read 1 file doesn\'t exist: {lane_data[0]["location"]}'
                 )
                 return None
-            if not file_exists(lane_data[1]['location']):
+            if check_existence and not file_exists(lane_data[1]['location']):
                 logger.error(
                     f'ERROR: read 2 file doesn\'t exist: {lane_data[1]["location"]}'
                 )

--- a/batch_seqr_loader/find_inputs.py
+++ b/batch_seqr_loader/find_inputs.py
@@ -354,7 +354,7 @@ def sm_verify_reads_data(  # pylint: disable=too-many-return-statements
         fqs1 = []
         fqs2 = []
         for lane_data in reads_data:
-            assert len(lane_data) == 2
+            assert len(lane_data) == 2, lane_data
             if not file_exists(lane_data[0]['location']):
                 logger.error(
                     f'ERROR: read 1 file doesn\'t exist: {lane_data[0]["location"]}'

--- a/batch_seqr_loader/scripts/make_annotated_mt.py
+++ b/batch_seqr_loader/scripts/make_annotated_mt.py
@@ -17,7 +17,8 @@ logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
 logger.setLevel(logging.INFO)
 
 GENOME_VERSION = 'GRCh38'
-REF_BUCKET = 'gs://cpg-reference/hg38/v1'
+REF_BUCKET = 'gs://cpg-reference'
+BROAD_REF_BUCKET = f'{REF_BUCKET}/hg38/v1'
 SEQR_REF_BUCKET = 'gs://cpg-seqr-reference-data'
 REF_HT = f'{SEQR_REF_BUCKET}/GRCh38/all_reference_data/v2/combined_reference_data_grch38-2.0.3.ht'
 CLINVAR_HT = f'{SEQR_REF_BUCKET}/GRCh38/clinvar/clinvar.GRCh38.2020-06-15.ht'
@@ -360,7 +361,7 @@ def add_37_coordinates(mt):
     """
     rg37 = hl.get_reference('GRCh37')
     rg38 = hl.get_reference('GRCh38')
-    rg38.add_liftover(join(REF_BUCKET, 'grch38_to_grch37.over.chain.gz'), rg37)
+    rg38.add_liftover(join(REF_BUCKET, 'liftover/grch38_to_grch37.over.chain.gz'), rg37)
     mt = mt.annotate_rows(rg37_locus=hl.liftover(mt.locus, 'GRCh37'))
     return mt
 

--- a/batch_seqr_loader/sm_utils.py
+++ b/batch_seqr_loader/sm_utils.py
@@ -218,11 +218,16 @@ def find_analyses_by_sid(
     sample (e.g. cram, gvcf)
     """
     analysis_per_sid: Dict[str, Analysis] = dict()
-    datas = aapi.get_latest_analysis_for_samples_and_type(
-        project=analysis_project,
-        analysis_type=analysis_type,
-        request_body=sample_ids,
-    )
+    try:
+        logger.info(f'Querying analysis entries for project {analysis_project}')
+        datas = aapi.get_latest_analysis_for_samples_and_type(
+            project=analysis_project,
+            analysis_type=analysis_type,
+            request_body=sample_ids,
+        )
+    except exceptions.ApiException:
+        return dict()
+
     for data in datas:
         a = _parse_analysis(data)
         if not a:

--- a/batch_seqr_loader/utils.py
+++ b/batch_seqr_loader/utils.py
@@ -20,8 +20,8 @@ AR_REPO = 'australia-southeast1-docker.pkg.dev/cpg-common/images'
 GATK_VERSION = '4.2.2.0-cpgfix00'  # Our fork with a couple of fixes:
 # https://github.com/populationgenomics/production-pipelines/tree/initial/dockers/gatk
 GATK_IMAGE = f'{AR_REPO}/gatk:{GATK_VERSION}'
-PICARD_IMAGE = f'{AR_REPO}/picard-cloud:2.23.8'
-ALIGNMENT_IMAGE = f'{AR_REPO}/alignment:v4'
+PICARD_IMAGE = f'{AR_REPO}/picard_samtools:v0'
+ALIGNMENT_IMAGE = f'{AR_REPO}/alignment:v3'
 SOMALIER_IMAGE = f'{AR_REPO}/somalier:latest'
 PEDDY_IMAGE = f'{AR_REPO}/peddy:0.4.8--pyh5e36f6f_0'
 GNARLY_IMAGE = f'{AR_REPO}/gnarly_genotyper:hail_ukbb_300K'
@@ -32,14 +32,14 @@ NUMBER_OF_HAPLOTYPE_CALLER_INTERVALS = 50
 NUMBER_OF_GENOMICS_DB_INTERVALS = 50
 NUMBER_OF_DATAPROC_WORKERS = 50
 
-REF_BUCKET = 'gs://cpg-reference/hg38'
+REF_BUCKET = 'gs://cpg-reference'
 NOALT_REGIONS = join(REF_BUCKET, 'noalt.bed')
 SOMALIER_SITES = join(REF_BUCKET, 'somalier/v0/sites.hg38.vcf.gz')
 
-GATK_REF_BUCKET = f'{REF_BUCKET}/v1'
-REF_FASTA = join(GATK_REF_BUCKET, 'Homo_sapiens_assembly38.fasta')
-DBSNP_VCF = join(GATK_REF_BUCKET, 'Homo_sapiens_assembly38.dbsnp138.vcf')
-UNPADDED_INTERVALS = join(GATK_REF_BUCKET, 'hg38.even.handcurated.20k.intervals')
+BROAD_REF_BUCKET = f'{REF_BUCKET}/hg38/v1'
+REF_FASTA = join(BROAD_REF_BUCKET, 'Homo_sapiens_assembly38.fasta')
+DBSNP_VCF = join(BROAD_REF_BUCKET, 'Homo_sapiens_assembly38.dbsnp138.vcf')
+UNPADDED_INTERVALS = join(BROAD_REF_BUCKET, 'hg38.even.handcurated.20k.intervals')
 
 DATAPROC_PACKAGES = [
     'seqr-loader',
@@ -119,11 +119,11 @@ def get_refs(b: hb.Batch) -> Tuple:
         fai=REF_FASTA + '.fai',
         dict=REF_FASTA.replace('.fasta', '').replace('.fna', '').replace('.fa', '')
         + '.dict',
+        sa=REF_FASTA + '.sa',
         amb=REF_FASTA + '.amb',
         ann=REF_FASTA + '.ann',
         pac=REF_FASTA + '.pac',
-        o123=REF_FASTA + '.0123',
-        bwa2bit64=REF_FASTA + '.bwt.2bit.64',
+        bwt=REF_FASTA + '.bwt',
     )
     noalt_regions = b.read_input(NOALT_REGIONS)
     return reference, bwa_reference, noalt_regions

--- a/batch_seqr_loader/utils.py
+++ b/batch_seqr_loader/utils.py
@@ -6,12 +6,10 @@ import hashlib
 import os
 import subprocess
 from os.path import join
-from typing import Iterable, Tuple, Optional, Dict
+from typing import Iterable, Tuple
 import logging
 from google.cloud import storage
 import hailtop.batch as hb
-from hailtop.batch import Batch
-from hailtop.batch.job import Job
 
 logger = logging.getLogger(__file__)
 logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
@@ -129,112 +127,6 @@ def get_refs(b: hb.Batch) -> Tuple:
     )
     noalt_regions = b.read_input(NOALT_REGIONS)
     return reference, bwa_reference, noalt_regions
-
-
-def make_sm_in_progress_job(*args, **kwargs) -> Job:
-    """
-    Creates a job that updates the sample metadata server entry analysis status
-    to "in-progress"
-    """
-    kwargs['status'] = 'in-progress'
-    return make_sm_update_status_job(*args, **kwargs)
-
-
-def make_sm_completed_job(*args, **kwargs) -> Job:
-    """
-    Creates a job that updates the sample metadata server entry analysis status
-    to "completed"
-    """
-    kwargs['status'] = 'completed'
-    return make_sm_update_status_job(*args, **kwargs)
-
-
-def make_sm_update_status_job(
-    b: Batch,
-    project: str,
-    analysis_id: str,
-    analysis_type: str,
-    status: str,
-    sample_name: Optional[str] = None,
-    project_name: Optional[str] = None,
-) -> Job:
-    """
-    Creates a job that updates the sample metadata server entry analysis status.
-    """
-    assert status in ['in-progress', 'failed', 'completed', 'queued']
-    job_name = ''
-    if project_name and sample_name:
-        job_name += f'{project_name}/{sample_name}: '
-    job_name += f'Update SM: {analysis_type} to {status}'
-    j = b.new_job(job_name)
-    j.image(SM_IMAGE)
-    j.command(
-        f"""
-set -o pipefail
-set -ex
-
-export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
-gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-export SM_DEV_DB_PROJECT={project}
-export SM_ENVIRONMENT=PRODUCTION
-
-cat <<EOT >> update.py
-from sample_metadata.api import AnalysisApi
-from sample_metadata import AnalysisUpdateModel
-aapi = AnalysisApi()
-aapi.update_analysis_status(
-    analysis_id='{analysis_id}',
-    analysis_update_model=AnalysisUpdateModel(status='{status}'),
-)
-EOT
-python update.py
-    """
-    )
-    return j
-
-
-def replace_paths_to_test(s: Dict) -> Optional[Dict]:
-    """
-    Replace paths of all files in -main namespace to -test namespsace,
-    and return None if files in -test are not found.
-    :param s:
-    :return:
-    """
-
-    def fix(fpath):
-        fpath = fpath.replace('-main-upload/', '-test-upload/')
-        if not file_exists(fpath):
-            return None
-        return fpath
-
-    try:
-        reads_type = s['meta']['reads_type']
-        if reads_type in ('bam', 'cram'):
-            fpath = s['meta']['reads'][0]['location']
-            fpath = fix(fpath)
-            if not fpath:
-                return None
-            s['meta']['reads'][0]['location'] = fpath
-
-            fpath = s['meta']['reads'][0]['secondaryFiles'][0]['location']
-            fpath = fix(fpath)
-            if not fpath:
-                return None
-            s['meta']['reads'][0]['secondaryFiles'][0]['location'] = fpath
-
-        elif reads_type == 'fastq':
-            for li in range(len(s['meta']['reads'])):
-                for rj in range(len(s['meta']['reads'][li])):
-                    fpath = s['meta']['reads'][li][rj]['location']
-                    fpath = fix(fpath)
-                    if not fpath:
-                        return None
-                    s['meta']['reads'][li][rj]['location'] = fpath
-
-        logger.info(f'Found test sample {s["id"]}')
-        return s
-    except Exception:  # pylint: disable=broad-except
-        return None
 
 
 def gsutil_cp(

--- a/batch_seqr_loader/vqsr.py
+++ b/batch_seqr_loader/vqsr.py
@@ -8,7 +8,7 @@ import logging
 import hailtop.batch as hb
 from hailtop.batch.job import Job
 import utils
-from utils import GATK_REF_BUCKET
+from utils import BROAD_REF_BUCKET
 
 logger = logging.getLogger('VQSR')
 logger.setLevel('INFO')
@@ -114,35 +114,35 @@ def make_vqsr_jobs(
     """
 
     # Reference files. All options have defaults.
-    dbsnp_vcf = os.path.join(GATK_REF_BUCKET, 'Homo_sapiens_assembly38.dbsnp138.vcf')
+    dbsnp_vcf = os.path.join(BROAD_REF_BUCKET, 'Homo_sapiens_assembly38.dbsnp138.vcf')
     dbsnp_vcf_index = os.path.join(
-        GATK_REF_BUCKET, 'Homo_sapiens_assembly38.dbsnp138.vcf.idx'
+        BROAD_REF_BUCKET, 'Homo_sapiens_assembly38.dbsnp138.vcf.idx'
     )
-    hapmap_resource_vcf = os.path.join(GATK_REF_BUCKET, 'hapmap_3.3.hg38.vcf.gz')
+    hapmap_resource_vcf = os.path.join(BROAD_REF_BUCKET, 'hapmap_3.3.hg38.vcf.gz')
     hapmap_resource_vcf_index = os.path.join(
-        GATK_REF_BUCKET, 'hapmap_3.3.hg38.vcf.gz.tbi'
+        BROAD_REF_BUCKET, 'hapmap_3.3.hg38.vcf.gz.tbi'
     )
-    omni_resource_vcf = os.path.join(GATK_REF_BUCKET, '1000G_omni2.5.hg38.vcf.gz')
+    omni_resource_vcf = os.path.join(BROAD_REF_BUCKET, '1000G_omni2.5.hg38.vcf.gz')
     omni_resource_vcf_index = os.path.join(
-        GATK_REF_BUCKET, '1000G_omni2.5.hg38.vcf.gz.tbi'
+        BROAD_REF_BUCKET, '1000G_omni2.5.hg38.vcf.gz.tbi'
     )
     one_thousand_genomes_resource_vcf = os.path.join(
-        GATK_REF_BUCKET, '1000G_phase1.snps.high_confidence.hg38.vcf.gz'
+        BROAD_REF_BUCKET, '1000G_phase1.snps.high_confidence.hg38.vcf.gz'
     )
     one_thousand_genomes_resource_vcf_index = os.path.join(
-        GATK_REF_BUCKET, '1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi'
+        BROAD_REF_BUCKET, '1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi'
     )
     mills_resource_vcf = os.path.join(
-        GATK_REF_BUCKET, 'Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
+        BROAD_REF_BUCKET, 'Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
     )
     mills_resource_vcf_index = os.path.join(
-        GATK_REF_BUCKET, 'Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi'
+        BROAD_REF_BUCKET, 'Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi'
     )
     axiom_poly_resource_vcf = os.path.join(
-        GATK_REF_BUCKET, 'Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz'
+        BROAD_REF_BUCKET, 'Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz'
     )
     axiom_poly_resource_vcf_index = os.path.join(
-        GATK_REF_BUCKET,
+        BROAD_REF_BUCKET,
         'Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
     )
     dbsnp_vcf = b.read_input_group(base=dbsnp_vcf, index=dbsnp_vcf_index)


### PR DESCRIPTION
* Switch to standard bwa (bwa-mem2 has troubles with some samples: https://batch.hail.populationgenomics.org.au/batches/5700)
* Add `--hc-shards-num` option to control number of intervals for HC. We want to process large datasets with fewer intervals to avoid too many jobs that cause [hitting](https://batch.hail.populationgenomics.org.au/batches/5720/jobs/2501) the GCP requests quota limit.
* Add `--skip-check-inputs-existence` and `--skip-update-sm-db` for faster pipeline startup (useful for tests and debugging)
* Use Picard for dedupping.
* Pass the fasta to ReblockGVCF.